### PR TITLE
[Feat] Modal 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,124 @@
+import { css } from '@emotion/react';
+import { createPortal } from 'react-dom';
+
+import useModalStore from '@/stores/modalStore';
+import theme from '@/styles/theme';
+
+const Modal = () => {
+  const { isOpen, modalData, closeModal } = useModalStore();
+
+  if (!isOpen || !modalData) return null;
+
+  const { type, title, desc, actionButton, onAction } = modalData;
+
+  const onClickButton = () => {
+    onAction();
+    closeModal();
+  };
+
+  const modalRoot = document.getElementById('modal-root');
+  if (!modalRoot) {
+    console.error('modal-root를 찾지 못함!');
+    return null;
+  }
+
+  return createPortal(
+    <div css={modalBackgroundStyle}>
+      <div css={modalStyle}>
+        <div css={titleStyle}>{title}</div>
+        <div css={descStyle}>{desc}</div>
+        <div css={modalButtonStyle}>
+          <button onClick={closeModal} css={cancelButtonStyle}>
+            취소
+          </button>
+          <button onClick={onClickButton} css={getButtonStyle(type)}>
+            {actionButton}
+          </button>
+        </div>
+      </div>
+    </div>,
+    modalRoot
+  );
+};
+
+const modalBackgroundStyle = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+`;
+
+const modalStyle = css`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 500px;
+  height: 300px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: ${theme.colors.main.white};
+  border-radius: 10px;
+`;
+
+const titleStyle = css`
+  font-size: ${theme.typography.fontSizes.subtitle.lg};
+  font-weight: ${theme.typography.fontWeight.bold};
+  line-height: ${theme.typography.lineHeights.md};
+  margin-bottom: 8px;
+`;
+
+const descStyle = css`
+  white-space: pre-line;
+  text-align: center;
+  font-size: ${theme.typography.fontSizes.caption};
+  font-weight: ${theme.typography.fontWeight.medium};
+  line-height: ${theme.typography.lineHeights.lg};
+  margin-bottom: 50px;
+  color: ${theme.colors.gray[500]};
+`;
+
+const baseButtonStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  padding: 0 32px;
+  font-size: ${theme.typography.fontSizes.caption};
+  font-weight: ${theme.typography.fontWeight.bold};
+  line-height: ${theme.typography.lineHeights.sm};
+`;
+
+const modalButtonStyle = css`
+  display: flex;
+  gap: 12px;
+`;
+
+const cancelButtonStyle = css`
+  ${baseButtonStyle};
+  background-color: ${theme.colors.gray[100]};
+  color: ${theme.colors.gray[500]};
+`;
+
+const getButtonStyle = (type: 'confirm' | 'warning') => {
+  if (type === 'confirm') {
+    return css`
+      ${baseButtonStyle};
+      background-color: ${theme.colors.main.primary};
+      color: ${theme.colors.main.white};
+    `;
+  } else if (type === 'warning') {
+    return css`
+      ${baseButtonStyle};
+      background-color: ${theme.colors.main.alert};
+      color: ${theme.colors.main.white};
+    `;
+  }
+};
+
+export default Modal;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,12 @@
 import InputTestPage from '@/pages/test-page/InputTestPage';
+import ModalTestPage from '@/pages/test-page/ModalTestPage';
 
 const HomePage = () => (
   <div>
     <h1>메인페이지</h1>
     <div>
-      <InputTestPage />
+      {/* <InputTestPage /> */}
+      <ModalTestPage />
     </div>
   </div>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,12 +1,10 @@
 import InputTestPage from '@/pages/test-page/InputTestPage';
-import ModalTestPage from '@/pages/test-page/ModalTestPage';
 
 const HomePage = () => (
   <div>
     <h1>메인페이지</h1>
     <div>
-      {/* <InputTestPage /> */}
-      <ModalTestPage />
+      <InputTestPage />
     </div>
   </div>
 );

--- a/src/pages/test-page/ModalTestPage.tsx
+++ b/src/pages/test-page/ModalTestPage.tsx
@@ -1,0 +1,48 @@
+import Modal from '@/components/common/Modal';
+import useModalStore from '@/stores/modalStore';
+
+const ModalTestPage = () => {
+  const { openModal } = useModalStore();
+
+  const onClickRegister = () => {
+    openModal({
+      type: 'confirm',
+      title: '전략 등록',
+      desc: '등록된 전략은 마이페이지에서 확인 가능합니다.',
+      onAction: () => console.log('등록됨'),
+    });
+  };
+
+  const onClickModify = () => {
+    openModal({
+      type: 'confirm',
+      title: '전략 수정',
+      desc: `수정된 전략은 전략 상세페이지에서 확인 가능합니다.`,
+      actionButton: '수정',
+      onAction: () => console.log('수정됨'),
+    });
+  };
+
+  const onClickDelete = () => {
+    openModal({
+      type: 'warning',
+      title: '전략 삭제',
+      desc: `등록한 전략은 3일간 매매 일지 입력을 완료한 후 \n 전략승인 요청 할 수 있습니다`,
+      onAction: () => console.log('삭제됨'),
+    });
+  };
+
+  return (
+    <div>
+      <h1>ModalTestPage</h1>
+      <button onClick={onClickRegister}>등록하기</button>
+      &nbsp; &nbsp; &nbsp;
+      <button onClick={onClickModify}>수정하기</button>
+      &nbsp; &nbsp; &nbsp;
+      <button onClick={onClickDelete}>삭제하기</button>
+      <Modal />
+    </div>
+  );
+};
+
+export default ModalTestPage;

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+type ModalType = 'confirm' | 'warning';
+
+interface ModalData {
+  type: ModalType;
+  title: string;
+  desc: string;
+  actionButton?: string;
+  onAction: () => void;
+}
+
+interface ModalStore {
+  isOpen: boolean;
+  modalData: ModalData | null;
+  openModal: (data: ModalData) => void;
+  closeModal: () => void;
+}
+
+const useModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  modalData: null,
+  openModal: (data: ModalData) =>
+    set({ isOpen: true, modalData: { actionButton: '확인', ...data } }),
+  closeModal: () => set({ isOpen: false, modalData: null }),
+}));
+
+export default useModalStore;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #23

## 📋 작업 내용

- ModalType에 따라 사용 (confirm: 초록버튼, warning: 주황버튼)
- zustand 사용해서 전역상태로 모달 열기 및 닫기
- createPotarl을 사용해 모달을 `#modal-root` 요소에 렌더링, 앱 내 DOM 구조와 상관없이 모달을 최상단 레이어로 띄울 수 있도록 함
- actionButton 클릭 시 onAction 콜백을 실행하고 자동으로 모달이 닫히도록 설정
- actionButton 설정 안할시 기본으로 '확인' 버튼
- 모달 설명(desc) 줄바꿈 하고싶다면 /n 사용

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![Nov-12-2024 00-53-21](https://github.com/user-attachments/assets/96c16eb6-d861-4033-8377-05f384a8f80d)

## 📄 기타

사용 방법
```tsx
import Modal from '@/components/common/Modal';
import useModalStore from '@/stores/modalStore';

const ModalTestPage = () => {
  const { openModal } = useModalStore();

  const onClickRegister = () => {
    openModal({
      type: 'confirm',
      title: '전략 등록',
      desc: '등록된 전략은 마이페이지에서 확인 가능합니다.',
      onAction: () => console.log('등록됨'),
    });
  };

  const onClickModify = () => {
    openModal({
      type: 'confirm',
      title: '전략 수정',
      desc: `수정된 전략은 전략 상세페이지에서 확인 가능합니다.`,
      actionButton: '수정',
      onAction: () => console.log('수정됨'),
    });
  };

  const onClickDelete = () => {
    openModal({
      type: 'warning',
      title: '전략 삭제',
      desc: `등록한 전략은 3일간 매매 일지 입력을 완료한 후 \n 전략승인 요청 할 수 있습니다`,
      onAction: () => console.log('삭제됨'),
    });
  };

  return (
    <div>
      <h1>ModalTestPage</h1>
      <button onClick={onClickRegister}>등록하기</button>
      <button onClick={onClickModify}>수정하기</button>
      <button onClick={onClickDelete}>삭제하기</button>
      <Modal />
    </div>
  );
};

export default ModalTestPage;
```

## Sourcery에 의한 요약

확인 및 경고 유형을 지원하는 Modal 컴포넌트를 추가하고, 글로벌 상태 관리를 위해 zustand를 통해 관리합니다. 모달은 다른 콘텐츠 위에 나타나도록 createPortal을 사용하여 렌더링됩니다. 테스트 페이지를 추가하고 HomePage를 업데이트하여 ModalTestPage를 포함시킴으로써 애플리케이션에 Modal 컴포넌트를 통합합니다.

새로운 기능:
- 다양한 유형(확인 및 경고)을 지원하고 사용자 정의 가능한 액션 버튼과 설명을 제공하는 재사용 가능한 Modal 컴포넌트를 구현합니다.
- zustand를 사용하여 모달의 글로벌 상태 관리를 도입하여 애플리케이션 어디에서나 모달을 열고 닫을 수 있도록 합니다.

향상된 기능:
- createPortal을 사용하여 모달을 렌더링하여 DOM 구조와 상관없이 애플리케이션의 최상위 레이어에 나타나도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Modal component with support for confirm and warning types, managed via zustand for global state control. Modals are rendered using createPortal to ensure they appear above other content. Integrate the Modal component into the application by adding a test page and updating the HomePage to include the ModalTestPage.

New Features:
- Implement a reusable Modal component that supports different types (confirm and warning) with customizable action buttons and descriptions.
- Introduce a global state management for modals using zustand, allowing modals to be opened and closed from anywhere in the application.

Enhancements:
- Render modals using createPortal to ensure they appear on the topmost layer of the application, independent of the DOM structure.

</details>