### PR TITLE
[Feat] Pagination 컴포넌트 구현

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -4,7 +4,6 @@ import {
   MdKeyboardArrowRight,
   MdKeyboardDoubleArrowLeft,
   MdKeyboardDoubleArrowRight,
-  MdMoreHoriz,
 } from 'react-icons/md';
 
 import theme from '@/styles/theme';
@@ -58,11 +57,6 @@ const Pagination = ({ totalPage, limit, page, setPage }: paginationProps) => {
           {pageNum}
         </button>
       ))}
-      {endPage < totalPage && (
-        <div css={NumberBtn} aria-disabled='true'>
-          <MdMoreHoriz size={12} /> <button css={NumberBtn}>{totalPage}</button>
-        </div>
-      )}
       <button css={ArrowBtn} onClick={handleNext} disabled={page === totalPage}>
         <MdKeyboardArrowRight size={24} />
       </button>
@@ -86,7 +80,7 @@ const PaginationWrapper = css`
     font-weight: ${theme.typography.fontWeight.regular};
     line-height: ${theme.typography.lineHeights.lg};
     background-color: inherit;
-    border-radius: 8px;
+    border-radius: 4px;
     color: ${theme.colors.gray[400]};
     width: 24px;
     height: 24px;
@@ -111,12 +105,6 @@ const NumberBtn = css`
   &:hover {
     background-color: ${theme.colors.gray[50]};
     color: ${theme.colors.gray[400]};
-  }
-
-  &[aria-disabled='true'] {
-    color: ${theme.colors.gray[400]};
-    cursor: not-allowed;
-    pointer-events: none;
   }
 
   &:disabled {

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,138 @@
+import { css } from '@emotion/react';
+import {
+  MdKeyboardArrowLeft,
+  MdKeyboardArrowRight,
+  MdKeyboardDoubleArrowLeft,
+  MdKeyboardDoubleArrowRight,
+  MdMoreHoriz,
+} from 'react-icons/md';
+
+import theme from '@/styles/theme';
+
+interface paginationProps {
+  totalPage: number; //전체 페이지 갯수
+  limit: number; //한 페이지에 보여질 목록의 갯수 (서버에 요청할 갯수 )
+  page: number; //현재 페이지 번호
+  setPage: (page: number) => void;
+}
+
+const Pagination = ({ totalPage, limit, page, setPage }: paginationProps) => {
+  const handleFirst = () => setPage(1);
+  const handleEnd = () => setPage(totalPage);
+
+  const handlePrevious = () => {
+    if (page > 1) {
+      setPage(page - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (page < totalPage) {
+      setPage(page + 1);
+    }
+  };
+
+  if (totalPage <= 1) return null;
+
+  const startPage = Math.floor((page - 1) / limit) * limit + 1;
+  const endPage = Math.min(startPage + limit - 1, totalPage);
+  const pages = Array.from({ length: endPage - startPage + 1 }, (_, idx) => startPage + idx);
+
+  return (
+    <div css={PaginationWrapper}>
+      <button css={ArrowBtn} onClick={handleFirst} disabled={page === 1}>
+        <MdKeyboardDoubleArrowLeft size={24} />
+      </button>
+      <button css={ArrowBtn} onClick={handlePrevious} disabled={page === 1}>
+        <MdKeyboardArrowLeft size={24} />
+      </button>
+      {pages.map((pageNum) => (
+        <button
+          css={css`
+            ${NumberBtn};
+            ${page === pageNum && ActiveBtn}
+          `}
+          key={pageNum}
+          onClick={() => setPage(pageNum)}
+        >
+          {pageNum}
+        </button>
+      ))}
+      {endPage < totalPage && (
+        <div css={NumberBtn} aria-disabled='true'>
+          <MdMoreHoriz size={12} /> <button css={NumberBtn}>{totalPage}</button>
+        </div>
+      )}
+      <button css={ArrowBtn} onClick={handleNext} disabled={page === totalPage}>
+        <MdKeyboardArrowRight size={24} />
+      </button>
+      <button css={ArrowBtn} onClick={handleEnd} disabled={page === totalPage}>
+        <MdKeyboardDoubleArrowRight size={24} />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;
+
+const PaginationWrapper = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+
+  button {
+    font-size: ${theme.typography.fontSizes.caption};
+    font-weight: ${theme.typography.fontWeight.regular};
+    line-height: ${theme.typography.lineHeights.lg};
+    background-color: inherit;
+    border-radius: 8px;
+    color: ${theme.colors.gray[400]};
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+
+    &:disabled {
+      color: ${theme.colors.gray[200]};
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+  }
+`;
+
+const NumberBtn = css`
+  font-size: ${theme.typography.fontSizes.caption};
+  font-weight: ${theme.typography.fontWeight.regular};
+  line-height: ${theme.typography.lineHeights.lg};
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    background-color: ${theme.colors.gray[50]};
+    color: ${theme.colors.gray[400]};
+  }
+
+  &[aria-disabled='true'] {
+    color: ${theme.colors.gray[400]};
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  &:disabled {
+    color: ${theme.colors.gray[200]};
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+`;
+
+const ArrowBtn = css`
+  &:hover {
+    color: ${theme.colors.gray[500]};
+  }
+`;
+
+const ActiveBtn = css`
+  background-color: ${theme.colors.teal[50]} !important;
+  color: ${theme.colors.teal[600]} !important;
+`;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,10 @@
-import ToastTestPage from '@/pages/test-page/ToastTestPage';
+import PaginationTestPage from './test-page/PaginationTestPage';
 
 const HomePage = () => (
   <div>
     <h1>메인페이지</h1>
     <div>
-      <ToastTestPage />
+      <PaginationTestPage />
     </div>
   </div>
 );

--- a/src/pages/test-page/PaginationTestPage.tsx
+++ b/src/pages/test-page/PaginationTestPage.tsx
@@ -61,13 +61,13 @@ const PaginationContainer = css`
 
 const TableStyle = css`
   width: 100%;
-  border-collapse: collpse;
+  border-collapse: collapse;
   margin-bottom: 20px;
 
   td,
   tr {
     border: 1px solid black;
-    padding: 12x;
+    padding: 12px;
     text-align: center;
   }
 

--- a/src/pages/test-page/PaginationTestPage.tsx
+++ b/src/pages/test-page/PaginationTestPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import Pagination from '@/components/common/Pagination';
+
+const mockData = Array.from({ length: 220 }, (_, index) => ({
+  //여기 length값이랑 아래 limit값으로 조절하시면서 확인해보시면 됩니다.
+  id: index + 1,
+  title: `항목${index}`,
+  img: '/logo.svg',
+}));
+
+const PaginationTestPage = () => {
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const totalPages = Math.ceil(mockData.length / limit);
+
+  const Attribute = [
+    { id: 1, title: '번호' },
+    { id: 2, title: '아이콘' },
+    { id: 3, title: '제목' },
+  ];
+
+  //서버에 limit개씩 끊어서 달라고 요청할거기 때문에 실제로 api 받아와서 쓸 때 이거 따로 계산할 필요 없음
+  //받아온 데이터 그대로 map 돌려서 테이블에 넣으심 됩니다
+  const getCurrentPageData = () => {
+    const startIdx = (page - 1) * limit;
+    const endIdx = startIdx + limit;
+    return mockData.slice(startIdx, endIdx);
+  };
+
+  return (
+    <div css={PaginationContainer}>
+      <table css={TableStyle}>
+        <tr>
+          {Attribute.map((item) => (
+            <td key={item.id}>{item.title}</td>
+          ))}
+        </tr>
+        {getCurrentPageData().map((item) => (
+          <tr key={item.id}>
+            <td>{item.id}</td>
+            <td>{<img src={item.img} alt={`${item.img}-${item.id}`} />}</td>
+            <td>{item.title}</td>
+          </tr>
+        ))}
+      </table>
+      <Pagination totalPage={totalPages} limit={limit} page={page} setPage={setPage} />
+    </div>
+  );
+};
+
+export default PaginationTestPage;
+
+const PaginationContainer = css`
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const TableStyle = css`
+  width: 100%;
+  border-collapse: collpse;
+  margin-bottom: 20px;
+
+  td,
+  tr {
+    border: 1px solid black;
+    padding: 12x;
+    text-align: center;
+  }
+
+  img {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+`;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

공통으로 사용할 페이지네이션 컴포넌트를 생성했습니다.
props로 totalPage, limit, page, setPage를 전달해야합니다.
totalPage = 전체 목록 갯수 / limit (한 페이지 당 서버에 요청할 목록 갯수)

PaginationTestPage import 하신 후 테스트 해보실 수 있습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![Nov-13-2024 16-32-16](https://github.com/user-attachments/assets/693cedd2-1e02-44fd-86ca-d5bd080407db)

테이블은 무시해주세요.. 정말 테스트만을 위해 만들어둔 테이블이랍니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Summary by Sourcery

페이지를 탐색하기 위한 재사용 가능한 Pagination 컴포넌트를 구현하고, 그 기능을 검증하기 위한 테스트 페이지를 추가합니다.

새로운 기능:
- totalPage, limit, page, setPage와 같은 props를 사용하여 페이지를 탐색할 수 있는 재사용 가능한 Pagination 컴포넌트를 구현합니다.

테스트:
- 모의 데이터를 사용하여 Pagination 컴포넌트의 기능을 테스트하기 위한 PaginationTestPage를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a reusable Pagination component for navigating through pages and add a test page to verify its functionality.

New Features:
- Implement a reusable Pagination component that allows navigation through pages using props such as totalPage, limit, page, and setPage.

Tests:
- Add a PaginationTestPage to test the functionality of the Pagination component with mock data.

</details>