### PR TITLE
[fix] layout의 main 너비값 빼기

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,14 +1,12 @@
-import { css } from '@emotion/react';
 import { Outlet } from 'react-router-dom';
 
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
-import theme from '@/styles/theme';
 
 const RootLayout = () => (
   <div>
     <Header />
-    <main css={mainStyle}>
+    <main>
       <Outlet />
     </main>
     <Footer />
@@ -16,8 +14,3 @@ const RootLayout = () => (
 );
 
 export default RootLayout;
-
-const mainStyle = css`
-  max-width: ${theme.layout.width.content};
-  margin: 0 auto;
-`;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

layout의 main 너비값 빼기

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

버그 수정:
- RootLayout 컴포넌트에서 메인 콘텐츠의 최대 너비를 설정하고 중앙에 배치하는 CSS 스타일링을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove the CSS styling that set a maximum width and centered the main content in the RootLayout component.

</details>