### PR TITLE
[Design] 전략 상세 페이지 제목, 내용, 지표 영역 퍼블리싱 

### DIFF
--- a/src/components/page/strategy/StrategyContent.tsx
+++ b/src/components/page/strategy/StrategyContent.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const StrategyContent = ({ content }: { content: string }) => (
+  <div css={contentWrapper}>
+    <div css={contentStyle}>{content}</div>
+  </div>
+);
+
+const contentWrapper = css`
+  width: 100%;
+  height: 468px;
+  background-color: ${theme.colors.gray[50]};
+  display: flex;
+  padding: 16px 24px 20px 24px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin: 24px 0px;
+`;
+
+const contentStyle = css`
+  display: flex;
+  flex-direction: column;
+  white-space: pre-wrap;
+  justify-content: center;
+  flex: 1 0 0;
+  ${theme.textStyle.body.body3.styles};
+`;
+export default StrategyContent;

--- a/src/components/page/strategy/StrategyContent.tsx
+++ b/src/components/page/strategy/StrategyContent.tsx
@@ -10,7 +10,7 @@ const StrategyContent = ({ content }: { content: string }) => (
 
 const contentWrapper = css`
   width: 100%;
-  height: 468px;
+  min-height: 100px;
   background-color: ${theme.colors.gray[50]};
   display: flex;
   padding: 16px 24px 20px 24px;
@@ -24,7 +24,6 @@ const contentStyle = css`
   display: flex;
   flex-direction: column;
   white-space: pre-wrap;
-  justify-content: center;
   flex: 1 0 0;
   ${theme.textStyle.body.body3.styles};
 `;

--- a/src/components/page/strategy/StrategyIndicator.tsx
+++ b/src/components/page/strategy/StrategyIndicator.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+interface IndicatorProps {
+  cumulativeRate: number;
+  maximumRate: number;
+  avgProfit: number;
+  profitFactor: string;
+  winRate: number;
+}
+
+const StrategyIndicator = ({
+  cumulativeRate,
+  maximumRate,
+  avgProfit,
+  profitFactor,
+  winRate,
+}: IndicatorProps) => (
+  <div css={indicatorWrapperStyle}>
+    <div css={rateAreaStyle}>
+      <div css={titleStyle}>누적수익률</div>
+      <div css={rateContentStyle}>{cumulativeRate}</div>
+    </div>
+    <div css={rateAreaStyle}>
+      <div css={titleStyle}>최대자본인하율</div>
+      <div css={rateContentStyle}>{maximumRate}</div>
+    </div>
+    <div css={rateAreaStyle}>
+      <div css={titleStyle}>평균손익률</div>
+      <div css={rateContentStyle}>{avgProfit}</div>
+    </div>
+    <div css={rateAreaStyle}>
+      <div css={titleStyle}>Profit Factor</div>
+      <div css={rateContentStyle}>{profitFactor}</div>
+    </div>
+    <div css={rateAreaStyle}>
+      <div css={titleStyle}>승률</div>
+      <div css={rateContentStyle}>{winRate}</div>
+    </div>
+  </div>
+);
+
+const indicatorWrapperStyle = css`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: ${theme.colors.gray[50]};
+  padding: 32px;
+`;
+
+const rateAreaStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  flex: 1;
+`;
+
+const titleStyle = css``;
+
+const rateContentStyle = css`
+  margin-top: 10px;
+  ${theme.textStyle.subtitles.subtitle4};
+`;
+
+export default StrategyIndicator;

--- a/src/components/page/strategy/StrategyTitleSection.tsx
+++ b/src/components/page/strategy/StrategyTitleSection.tsx
@@ -1,0 +1,174 @@
+import { css } from '@emotion/react';
+import { useNavigate } from 'react-router-dom';
+
+import theme from '@/styles/theme';
+
+interface TitleProps {
+  title: string;
+  author: {
+    traderId: string;
+    traderName: string;
+    imgUrl: string;
+  };
+  date: string;
+  followers: number;
+}
+
+const StrategyTitleSection = ({ title, author, date, followers }: TitleProps) => {
+  const navigate = useNavigate();
+
+  const handleMoveProfile = (traderId: string) => {
+    navigate(`/traders/${traderId}`);
+  };
+
+  return (
+    <div css={containerStyle}>
+      <div css={tagAreaStyle}>
+        <div css={tagStyle}>태그</div>
+        <div css={tagStyle}>태그2</div>
+      </div>
+
+      <div css={titleAreaStyle}>
+        <div css={infoAreaStyle}>
+          <div css={titleStyle}>{title}</div>
+
+          <div css={authorInfoStyle}>
+            <button onClick={() => handleMoveProfile(author.traderId)} css={authorDetailsStyle}>
+              <img src={author.imgUrl} alt={author.traderName} css={authorImageStyle} />
+              <span css={authorNameStyle}>{author.traderName}</span>
+            </button>
+            <span css={postDateStyle}>작성일자 {date}</span>
+          </div>
+        </div>
+
+        <div css={followerAreaStyle}>
+          <div css={followerTextStyle}>팔로워</div>
+          <div>{followers}</div>
+          <div css={editDeleteStyle}>
+            <span css={editStyle}>수정</span>
+            <span css={deleteStyle}>삭제</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 16px;
+  align-self: stretch;
+`;
+
+const tagAreaStyle = css`
+  display: flex;
+  gap: 8px;
+`;
+
+const tagStyle = css`
+  display: flex;
+  padding: 0px 10px;
+  height: 21px;
+  align-items: center;
+  justify-content: center;
+  font-size: ${theme.buttons.label.sm.fontSize};
+  font-weight: ${theme.buttons.label.lg.fontWeight};
+  line-height: ${theme.buttons.label.lg.lineHeight};
+  background-color: ${theme.colors.teal[100]};
+`;
+
+const titleAreaStyle = css`
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+`;
+
+const infoAreaStyle = css`
+  display: flex;
+  flex-direction: column;
+  width: 921px;
+`;
+
+const titleStyle = css`
+  ${theme.textStyle.headings.h3};
+`;
+
+const authorInfoStyle = css`
+  gap: 8px;
+`;
+
+const authorDetailsStyle = css`
+  display: flex;
+  align-items: center;
+  padding: 8px 0px;
+  gap: 8px;
+  background: none;
+  border: none;
+  margin: 0;
+  cursor: pointer;
+  outline: none;
+`;
+
+const authorImageStyle = css`
+  width: 32px;
+  height: 32px;
+  border-radius: 32px;
+  object-fit: cover;
+`;
+
+const authorNameStyle = css`
+  ${theme.textStyle.subtitles.subtitle2};
+`;
+
+const postDateStyle = css`
+  display: flex;
+  flex-direction: column;
+  color: ${theme.colors.gray[400]};
+  ${theme.textStyle.captions.caption2};
+`;
+
+const followerAreaStyle = css`
+  display: flex;
+  flex-direction: column;
+  width: 100px;
+  align-items: center;
+  margin-top: 3px;
+  ${theme.textStyle.subtitles.subtitle2};
+`;
+
+const followerTextStyle = css`
+  font-size: ${theme.buttons.label.md.fontSize};
+  font-weight: ${theme.buttons.label.sm.fontWeight};
+`;
+
+const editDeleteStyle = css`
+  display: flex;
+  margin-top: 15px;
+  gap: 13px;
+`;
+
+const editStyle = css`
+  cursor: pointer;
+  color: ${theme.colors.gray[400]};
+  font-size: ${theme.buttons.label.md.fontSize};
+  font-weight: ${theme.buttons.label.sm.fontWeight};
+
+  &:hover {
+    color: ${theme.colors.main.black};
+  }
+`;
+
+const deleteStyle = css`
+  cursor: pointer;
+  color: ${theme.colors.gray[400]};
+  font-size: ${theme.buttons.label.md.fontSize};
+  font-weight: ${theme.buttons.label.sm.fontWeight};
+
+  &:hover {
+    color: ${theme.colors.main.black};
+  }
+`;
+
+export default StrategyTitleSection;

--- a/src/components/page/strategy/StrategyTitleSection.tsx
+++ b/src/components/page/strategy/StrategyTitleSection.tsx
@@ -43,7 +43,7 @@ const StrategyTitleSection = ({ title, author, date, followers }: TitleProps) =>
 
         <div css={followerAreaStyle}>
           <div css={followerTextStyle}>팔로워</div>
-          <div>{followers}</div>
+          <div css={followerTextStyle}>{followers}</div>
           <div css={editDeleteStyle}>
             <span css={editStyle}>수정</span>
             <span css={deleteStyle}>삭제</span>
@@ -134,18 +134,16 @@ const followerAreaStyle = css`
   flex-direction: column;
   width: 100px;
   align-items: center;
-  margin-top: 3px;
+  gap: 8px;
   ${theme.textStyle.subtitles.subtitle2};
 `;
 
 const followerTextStyle = css`
-  font-size: ${theme.buttons.label.md.fontSize};
-  font-weight: ${theme.buttons.label.sm.fontWeight};
+  height: 34px;
 `;
 
 const editDeleteStyle = css`
   display: flex;
-  margin-top: 15px;
   gap: 13px;
 `;
 

--- a/src/components/page/strategy/StrategyTitleSection.tsx
+++ b/src/components/page/strategy/StrategyTitleSection.tsx
@@ -73,9 +73,7 @@ const tagStyle = css`
   height: 21px;
   align-items: center;
   justify-content: center;
-  font-size: ${theme.buttons.label.sm.fontSize};
-  font-weight: ${theme.buttons.label.lg.fontWeight};
-  line-height: ${theme.buttons.label.lg.lineHeight};
+  ${theme.textStyle.captions.caption2};
   background-color: ${theme.colors.teal[100]};
 `;
 

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -53,7 +53,6 @@ const StrategyDetailPage = () => (
 
 const containerStyle = css`
   display: flex;
-  width: ${theme.layout.width.max};
   background-color: ${theme.colors.gray[100]};
   justify-content: center;
   flex-shrink: 0;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -1,6 +1,74 @@
+import { css } from '@emotion/react';
+
+import StrategyContent from '@/components/page/strategy/StrategyContent';
+import StrategyIndicator from '@/components/page/strategy/StrategyIndicator';
+import StrategyTitleSection from '@/components/page/strategy/StrategyTitleSection';
+import theme from '@/styles/theme';
+
+const strategyDummy = [
+  {
+    title: '전략 이름이 들어가는 자리입니다.',
+    author: {
+      traderId: 'investKing',
+      traderName: '나는야 투자왕',
+      imgUrl: '/logo.svg',
+    },
+    date: '2024.11.13(수) 23:25',
+    followers: 23,
+    content: `안녕하세요 침착해입니다.\n강의 이후로 뭔가 많이 지쳐있기도 했고..\n개인적으로 바쁜일들도 있어서 오랜만에 글 남기게 되었네요.. \n지독한 여름더위와 함께 여름 내내 시장이 참 어려웠던것 같습니다.\n9월도 시장이 반등하고는 있지만 여전히 시장에 돈이 많이 없어서\n까다로운 시장에 연속이구요.\n\n지속되는 하락장에 가는건 죄다 소형주에 테마주 뿐이 없었고\n종목들도 다 제가 좋아하는 자리에 있지 않아서\n비중태우기도 어렵고\n종베하면 손실났다가 또 복구하기 바쁘고\n이래저래 요몇달 계속 어려웠던 장세같습니다.\n\n그래서 저는 매매횟수도 많이 줄이고\n좋은 이벤트나 승률높은 자리와 비중태울 수 있는 종목이 있을때 승부를 보려고 계속 생각해왔고\n단타성향은 확 죽이고 스윙과 단기스윙에 많이 집중해왔습니다.`,
+    indicator: {
+      cumulativeRate: 53.81,
+      maximumRate: -13.6,
+      avgProfit: 5.69,
+      profitFactor: '1.54 : 1',
+      winRate: 60.36,
+    },
+  },
+];
+
 const StrategyDetailPage = () => (
-  <div>
-    <h1>전략 상세 페이지</h1>
+  <div css={containerStyle}>
+    <div css={contentStyle}>
+      {strategyDummy.map((strategy, index) => (
+        <div key={index}>
+          <StrategyTitleSection
+            title={strategy.title}
+            author={strategy.author}
+            date={strategy.date}
+            followers={strategy.followers}
+          />
+          <StrategyContent content={strategy.content} />
+          <StrategyIndicator
+            cumulativeRate={strategy.indicator.cumulativeRate}
+            maximumRate={strategy.indicator.maximumRate}
+            avgProfit={strategy.indicator.avgProfit}
+            profitFactor={strategy.indicator.profitFactor}
+            winRate={strategy.indicator.winRate}
+          />
+        </div>
+      ))}
+    </div>
   </div>
 );
+
+const containerStyle = css`
+  display: flex;
+  width: ${theme.layout.width.max};
+  background-color: ${theme.colors.gray[100]};
+  justify-content: center;
+  flex-shrink: 0;
+  margin: 0 auto;
+`;
+
+const contentStyle = css`
+  display: flex;
+  flex-direction: column;
+  margin-top: 95px;
+  ${theme.layout.width.content};
+  padding: 80px 80px 100px 80px;
+  box-sizing: border-box;
+  align-items: center;
+  background-color: ${theme.colors.main.white};
+`;
+
 export default StrategyDetailPage;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -10,7 +10,7 @@ const strategyDummy = [
     title: '전략 이름이 들어가는 자리입니다.',
     author: {
       traderId: 'investKing',
-      traderName: '나는야 투자왕',
+      traderName: '나는야투자왕',
       imgUrl: '/logo.svg',
     },
     date: '2024.11.13(수) 23:25',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

전략 상세페이지 퍼블리싱 작업 진행
상단 영역 (제목, 프로필, 팔로워 수 , 날짜) 컴포넌트 생성, 내용 영역 컴포넌트 생성, 주요지표 컴포넌트 생성

전략 상세 페이지의 경우 아직 모든 디자인이 완료되지 않은 상태이며 디자인이 나오는대로 수정할 예정입니다. 
상단의 태그 부분도 기업측의 아이콘 제공 여부가 결정되면 그에 따라서 변경하도록 하겠습니다.
더미데이터 부분도 퍼블리싱 작업 완료 후 MSW 작업 시에 갈아끼우도록 하겠습니닷

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
<img width="1511" alt="스크린샷 2024-11-14 오전 11 59 33" src="https://github.com/user-attachments/assets/5bbfa748-1525-43e2-a12a-cb2c438af6d8">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
