### PR TITLE
[Feat] 검색 입력 및 마이페이지 링크 추가 (#20)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
           <GlobalNav />
         </div>
         <div css={searchAndMyPageContainer}>
-          <SearchInput onSearch={handleButtonClick} />
+          <SearchInput onSearchSubmit={handleButtonClick} />
           <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.LIST} css={myPageStyle}>
             <BsPerson size={24} />
           </Link>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,12 +1,27 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
+import { BsPerson } from 'react-icons/bs';
 import { Link } from 'react-router-dom';
 
+import SearchInput from '@/components/common/SearchInput';
 import GlobalNav from '@/components/navigation/GlobalNav';
 import { ROUTES } from '@/constants/routes';
 import theme from '@/styles/theme';
 
 const Header = () => {
   const LOGO = 'SYSMETIC';
+
+  const [searchValue, setSearchValue] = useState('');
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  };
+
+  const handleButtonClick = () => {
+    console.log(searchValue);
+  };
+
   return (
     <header css={headerStyle}>
       <div css={containerStyle}>
@@ -17,6 +32,12 @@ const Header = () => {
             </Link>
           </h1>
           <GlobalNav />
+        </div>
+        <div css={searchAndMyPageContainer}>
+          <SearchInput onChange={handleSearch} onSearch={handleButtonClick} />
+          <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.LIST} css={myPageStyle}>
+            <BsPerson size={24} />
+          </Link>
         </div>
       </div>
     </header>
@@ -31,6 +52,7 @@ const headerStyle = css`
 const containerStyle = css`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   max-width: ${theme.layout.width.content};
   height: 100%;
   padding: 0px 20px;
@@ -41,6 +63,20 @@ const logoNavContainerStyle = css`
   display: flex;
   align-items: center;
   gap: 47px;
+`;
+
+const searchAndMyPageContainer = css`
+  display: flex;
+  align-items: center;
+  gap: 24px;
+`;
+
+const myPageStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
 `;
 
 export default Header;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,25 +1,17 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { BsPerson } from 'react-icons/bs';
 import { Link } from 'react-router-dom';
 
-import SearchInput from '@/components/common/SearchInput';
 import GlobalNav from '@/components/navigation/GlobalNav';
+import SearchInput from '@/components/page/search/SearchInput';
 import { ROUTES } from '@/constants/routes';
 import theme from '@/styles/theme';
 
 const Header = () => {
   const LOGO = 'SYSMETIC';
 
-  const [searchValue, setSearchValue] = useState('');
-
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchValue(e.target.value);
-  };
-
-  const handleButtonClick = () => {
-    console.log(searchValue);
+  const handleButtonClick = (value: string) => {
+    console.log(value);
   };
 
   return (
@@ -34,7 +26,7 @@ const Header = () => {
           <GlobalNav />
         </div>
         <div css={searchAndMyPageContainer}>
-          <SearchInput onChange={handleSearch} onSearch={handleButtonClick} />
+          <SearchInput onSearch={handleButtonClick} />
           <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.LIST} css={myPageStyle}>
             <BsPerson size={24} />
           </Link>

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -1,0 +1,61 @@
+import { css } from '@emotion/react';
+import { FiSearch } from 'react-icons/fi';
+
+import Input, { InputProps } from './Input';
+
+import theme from '@/styles/theme';
+
+interface SearchInputProps extends InputProps {
+  onSearch?: () => void;
+}
+
+const SearchInput = ({ onSearch, ...props }: SearchInputProps) => {
+  const handleSearch = () => {
+    if (onSearch) onSearch();
+  };
+
+  return (
+    <div css={searchContainerStyles}>
+      <button type='button' onClick={handleSearch} css={searchIconStyles}>
+        <FiSearch size={24} />
+      </button>
+      <Input
+        placeholder='내용을 입력해주세요'
+        {...props}
+        showClearButton
+        customStyle={css`
+          width: 300px;
+          text-indent: 10px;
+          padding-left: 36px;
+        `}
+      />
+    </div>
+  );
+};
+
+const searchContainerStyles = css`
+  position: relative;
+  display: inline-block;
+  width: 100%;
+`;
+
+const searchIconStyles = css`
+  z-index: 9;
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: ${theme.colors.gray[500]};
+
+  &:hover {
+    color: ${theme.colors.gray[700]};
+  }
+`;
+
+export default SearchInput;

--- a/src/components/page/search/SearchInput.tsx
+++ b/src/components/page/search/SearchInput.tsx
@@ -1,17 +1,24 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 import { FiSearch } from 'react-icons/fi';
 
-import Input, { InputProps } from './Input';
-
+import Input from '@/components/common/Input';
 import theme from '@/styles/theme';
 
-interface SearchInputProps extends InputProps {
-  onSearch?: () => void;
+interface SearchInputProps {
+  onSearch?: (value: string) => void;
 }
 
 const SearchInput = ({ onSearch, ...props }: SearchInputProps) => {
+  const [searchValue, setSearchValue] = useState('');
+
   const handleSearch = () => {
-    if (onSearch) onSearch();
+    if (onSearch) onSearch(searchValue);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
   };
 
   return (
@@ -21,13 +28,15 @@ const SearchInput = ({ onSearch, ...props }: SearchInputProps) => {
       </button>
       <Input
         placeholder='내용을 입력해주세요'
-        {...props}
+        value={searchValue}
+        onChange={handleChange}
         showClearButton
         customStyle={css`
           width: 300px;
           text-indent: 10px;
           padding-left: 36px;
         `}
+        {...props}
       />
     </div>
   );

--- a/src/components/page/search/SearchInput.tsx
+++ b/src/components/page/search/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { FiSearch } from 'react-icons/fi';
@@ -7,29 +7,36 @@ import Input from '@/components/common/Input';
 import theme from '@/styles/theme';
 
 interface SearchInputProps {
-  onSearch?: (value: string) => void;
+  onSearchSubmit?: (value: string) => void;
 }
 
-const SearchInput = ({ onSearch, ...props }: SearchInputProps) => {
+const SearchInput = ({ onSearchSubmit, ...props }: SearchInputProps) => {
   const [searchValue, setSearchValue] = useState('');
 
-  const handleSearch = () => {
-    if (onSearch) onSearch(searchValue);
+  const handleSearchButtonClick = () => {
+    if (onSearchSubmit) onSearchSubmit(searchValue);
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchValue(e.target.value);
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(event.target.value);
+  };
+
+  const handleInputEnterPress = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSearchButtonClick();
+    }
   };
 
   return (
     <div css={searchContainerStyles}>
-      <button type='button' onClick={handleSearch} css={searchIconStyles}>
+      <button type='button' onClick={handleSearchButtonClick} css={searchIconStyles}>
         <FiSearch size={24} />
       </button>
       <Input
         placeholder='내용을 입력해주세요'
         value={searchValue}
-        onChange={handleChange}
+        onChange={handleSearchChange}
+        onKeyPress={handleInputEnterPress}
         showClearButton
         customStyle={css`
           width: 300px;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

 close #20 


## 📋 작업 내용

1. 마이페이지는 현재 트레이더 페이지로 연결되어 있습니다. 원래는 API를 통해 사용자 role에 따라 다른 페이지로 연결되도록 구현할 예정입니다.
2. SearchInput 컴포넌트를 만들었습니다. 검색 입력 필드와 버튼을 따로 분리한 이유는, 추후 검색 값을 활용해 전략이나 트레이더 리스트를 필터링할 수 있도록 하기 위함입니다. 또한, Enter 키로도 검색이 가능하도록 하기 위해서도 버튼을 외부로 분리했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![Nov-14-2024 14-43-14](https://github.com/user-attachments/assets/760260c2-00e6-45ef-91ce-3e67cac7b466)



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

사용자 쿼리를 위한 SearchInput 컴포넌트와 헤더에 MyPage 링크를 추가하여 탐색 및 검색 기능을 향상시킵니다.

새로운 기능:
- 사용자가 검색 쿼리를 입력하고 버튼 또는 Enter 키를 통해 제출할 수 있는 SearchInput 컴포넌트를 추가합니다.
- 현재 트레이더 페이지로 연결되는 MyPage 섹션에 대한 링크를 도입하며, 향후 역할 기반 라우팅을 계획하고 있습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a SearchInput component for user queries and a MyPage link in the header, enhancing navigation and search functionality.

New Features:
- Add a SearchInput component to allow users to input search queries and submit them via a button or the Enter key.
- Introduce a link to the MyPage section, currently directing to the trader page, with plans for future role-based routing.

</details>