### PR TITLE
[Design] 전략 상세페이지 탭 메뉴 구현

### DIFF
--- a/src/components/page/strategy/StrategyTab.tsx
+++ b/src/components/page/strategy/StrategyTab.tsx
@@ -1,0 +1,77 @@
+import { css } from '@emotion/react';
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
+
+import theme from '@/styles/theme';
+
+interface TabProps {
+  tabs: itemProps[];
+}
+interface itemProps {
+  title: string;
+  component: React.ReactNode;
+}
+const StrategyTab = ({ tabs }: TabProps) => (
+  <div css={tabContainer}>
+    <TabGroup css={tabGroupStyle}>
+      <TabList css={tabListStyle}>
+        {tabs.map((tab, idx) => (
+          <Tab key={idx}>
+            {({ selected }) => <div css={[tabItemStyle, selected && selectedTab]}>{tab.title}</div>}
+          </Tab>
+        ))}
+      </TabList>
+      <TabPanels>
+        {tabs.map((tab, idx) => (
+          <TabPanel key={idx}>{tab.component}</TabPanel>
+        ))}
+      </TabPanels>
+    </TabGroup>
+  </div>
+);
+
+const tabContainer = css`
+  width: 100%;
+`;
+
+const tabGroupStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const tabListStyle = css`
+  display: flex;
+  align-items: center;
+  margin: 40px 0px;
+  button {
+    background-color: inherit;
+  }
+`;
+
+const tabItemStyle = css`
+  ${theme.textStyle.subtitles.subtitle2};
+  color: ${theme.colors.gray[400]};
+  display: flex;
+  justify-content: center;
+  border-bottom: 1px solid ${theme.colors.gray[400]};
+  align-items: center;
+  padding: 10px;
+  position: relative;
+`;
+
+const selectedTab = css`
+  ${theme.textStyle.subtitles.subtitle1};
+  color: ${theme.colors.main.black};
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background-color: ${theme.colors.main.primary};
+    transition: 0.3s ease;
+  }
+`;
+export default StrategyTab;

--- a/src/components/page/strategy/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy/tabmenu/AccountVerify.tsx
@@ -1,0 +1,2 @@
+const AccountVerify = () => <div>실계좌인증</div>;
+export default AccountVerify;

--- a/src/components/page/strategy/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy/tabmenu/DailyAnalysis.tsx
@@ -1,0 +1,2 @@
+const DailyAnalysis = () => <div>일간분석 테이블</div>;
+export default DailyAnalysis;

--- a/src/components/page/strategy/tabmenu/MonthlyAnalysis.tsx
+++ b/src/components/page/strategy/tabmenu/MonthlyAnalysis.tsx
@@ -1,0 +1,3 @@
+const MonthlyAnalysis = () => <div>월간분석 테이블</div>;
+
+export default MonthlyAnalysis;

--- a/src/components/page/strategy/tabmenu/Statistics.tsx
+++ b/src/components/page/strategy/tabmenu/Statistics.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Statistics = () => <div>통계 테이블</div>;
+
+export default Statistics;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -2,7 +2,12 @@ import { css } from '@emotion/react';
 
 import StrategyContent from '@/components/page/strategy/StrategyContent';
 import StrategyIndicator from '@/components/page/strategy/StrategyIndicator';
+import StrategyTab from '@/components/page/strategy/StrategyTab';
 import StrategyTitleSection from '@/components/page/strategy/StrategyTitleSection';
+import AccountVerify from '@/components/page/strategy/tabmenu/AccountVerify';
+import DailyAnalysis from '@/components/page/strategy/tabmenu/DailyAnalysis';
+import MonthlyAnalysis from '@/components/page/strategy/tabmenu/MonthlyAnalysis';
+import Statistics from '@/components/page/strategy/tabmenu/Statistics';
 import theme from '@/styles/theme';
 
 const strategyDummy = [
@@ -25,6 +30,24 @@ const strategyDummy = [
     },
   },
 ];
+const tabMenu = [
+  {
+    title: '통계',
+    component: <Statistics />,
+  },
+  {
+    title: '실계좌인증',
+    component: <AccountVerify />,
+  },
+  {
+    title: '일간분석',
+    component: <DailyAnalysis />,
+  },
+  {
+    title: '월간분석',
+    component: <MonthlyAnalysis />,
+  },
+];
 
 const StrategyDetailPage = () => (
   <div css={containerStyle}>
@@ -45,6 +68,7 @@ const StrategyDetailPage = () => (
             profitFactor={strategy.indicator.profitFactor}
             winRate={strategy.indicator.winRate}
           />
+          <StrategyTab tabs={tabMenu} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

전략 상세 페이지 탭 메뉴 구현
탭 클릭 시 해당되는 컴포넌트도 렌더링 될 수 있도록 연결해두었습니다.


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.
![Nov-14-2024 16-24-23](https://github.com/user-attachments/assets/b7ee30e7-b6f4-431c-8eb0-b54b0a1bde75)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

새로운 기능:
- 사용자들이 통계, 계정 인증, 일일 분석, 월간 분석과 같은 다양한 구성 요소 간에 전환할 수 있도록 전략 세부 페이지에 탭 메뉴를 구현합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Implement a tab menu on the strategy detail page to allow users to switch between different components such as statistics, account verification, daily analysis, and monthly analysis.

</details>