### PR TITLE
[Feat] 관리자 인증 페이지 UI 기능 구현 (#106)

### DIFF
--- a/src/components/page/signup/VerificationInput.tsx
+++ b/src/components/page/signup/VerificationInput.tsx
@@ -22,11 +22,11 @@ const VerificationInput = ({
   onTimeEnd,
   isDisabled = false, // 기본값 false
 }: VerificationInputProps) => {
-  const [timeLeft, setTimeLeft] = useState<number>(10); // 초기값 5분(300초)
+  const [timeLeft, setTimeLeft] = useState<number>(179); // 초기값 3분  => 179초
 
   // resetTimer가 변경될 때만 타이머 시작!
   useEffect(() => {
-    setTimeLeft(10); // 타이머 초기화
+    setTimeLeft(179); // 타이머 초기화
     onChange(''); // 입력값 초기화
   }, [resetTimer, onChange]);
 

--- a/src/components/page/signup/VerificationInput.tsx
+++ b/src/components/page/signup/VerificationInput.tsx
@@ -9,58 +9,44 @@ import { formatTime } from '@/utils/time';
 interface VerificationInputProps {
   value: string; // 부모컴포넌트에서 관리하는 입력값
   onChange: (value: string) => void; // 입력값 변경 콜백함수
-  isActive?: boolean; // 컴포넌트 활성화 여부
+  resetTimer?: number; // 타이머 리셋을 위한 상태
   onTimeEnd?: () => void; // 타이머 종료 콜백함수
+  isDisabled?: boolean; // 입력창 비활성화 여부
 }
 
 // 타이머 기능있는 인증번호 입력창 컴포넌트(인증번호입력+타이머)
 const VerificationInput = ({
   value,
   onChange,
-  isActive = false, // 기본값은 비활성화
+  resetTimer = 0,
   onTimeEnd,
+  isDisabled = false, // 기본값 false
 }: VerificationInputProps) => {
-  const [timeLeft, setTimeLeft] = useState<number | null>(null); // 초기값 null로 설정
+  const [timeLeft, setTimeLeft] = useState<number>(10); // 초기값 5분(300초)
 
-  // 활성화 상태가 되면 타이머 시작!
-  // isActive가 true로 변경될 때마다 타이머 재시작
+  // resetTimer가 변경될 때만 타이머 시작!
   useEffect(() => {
-    if (isActive) {
-      setTimeLeft(299); // 5분(300초) 타이머 시작 또는 타이머 재시작
-      onChange(''); // 입력값 초기화
-    }
-  }, [isActive, onChange]);
+    setTimeLeft(10); // 타이머 초기화
+    onChange(''); // 입력값 초기화
+  }, [resetTimer, onChange]);
 
   // 타이머 로직
   useEffect(() => {
-    // 비활성화 상태거나, timeLeft가 null이거나, 0이하일 때 타이머 종료
-    if (!isActive || timeLeft === null || timeLeft <= 0) {
-      // 타이머 종료 콜백함수 호출
-      if (timeLeft === 0) {
-        onTimeEnd?.();
-      }
+    // 타이머가 정확히 0일 때만 onTimeEnd 콜백함수 호출
+    if (timeLeft === 0) {
+      onTimeEnd?.();
       return;
     }
 
     const timer = setInterval(() => {
-      setTimeLeft((prev) => {
-        // 이전 값이 null이 아니고 0보다 크면 1초씩 감소
-        if (prev !== null) {
-          return prev - 1;
-        }
-        return prev;
-      });
+      setTimeLeft((prev) => prev - 1);
     }, 1000);
 
     // 컴포넌트 언마운트되면 타이머 종료
     return () => {
       clearInterval(timer);
     };
-  }, [timeLeft, isActive, onTimeEnd]);
-
-  if (!isActive) {
-    return null; // 비활성화 상태일 때는 null 반환
-  }
+  }, [timeLeft, onTimeEnd]);
 
   return (
     <div css={inputContainerStyle}>
@@ -71,7 +57,7 @@ const VerificationInput = ({
         onChange={(e) => onChange(e.target.value)}
         value={value}
         css={inputStyle}
-        disabled={timeLeft === 0} // 타이머 종료되면 입력창 비활성화
+        disabled={isDisabled || timeLeft === 0} // timeLeft가 0 이거나 isDisabled가 true이면 입력창 비활성화
       />
       <span css={timerStyle}>{timeLeft !== null ? formatTime(timeLeft) : ''}</span>
     </div>

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -1,42 +1,100 @@
 import { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
+import { useNavigate } from 'react-router-dom';
 
+import Button from '@/components/common/Button';
 import VerificationInput from '@/components/page/signup/VerificationInput';
+import { ROUTES } from '@/constants/routes';
 import theme from '@/styles/theme';
+import { validateCode } from '@/utils/validation';
 
 const AdminVerifyPage = () => {
-  const [isVerificationActive, setIsVerificationActive] = useState<boolean>(false);
+  const navigate = useNavigate();
   const [verificationCode, setVerificationCode] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [resetTimer, setResetTimer] = useState<number>(0); // 타이머 리셋을 위한 상태
+  const [shouldReset, setShouldReset] = useState(false);
+  const [isInputDisabled, setIsInputDisabled] = useState(false);
 
-  // 페이지 마운트하면 자동으로 인증번호 요청
+  // 재전송 처리를 위한 useEffect
   useEffect(() => {
-    requestAdminVerification();
-  }, []);
+    if (shouldReset) {
+      setErrorMessage('');
+      setResetTimer((prev) => prev + 1);
+      setIsInputDisabled(false); // 입력창 활성화
+      setShouldReset(false);
+    }
+  }, [shouldReset]);
+
+  // verificationCode가 변경될 때마다 실행
+  useEffect(() => {
+    // 입력값이 비어있다면 에러메시지 제거
+    if (!verificationCode) {
+      setErrorMessage('');
+    }
+  }, [verificationCode]);
 
   // 인증번호 재요청
-  const requestAdminVerification = () => {
+  const handleResend = () => {
+    setShouldReset(true);
+    // setState는 비동기이므로, 이 시점에서는 아직 errorMessage가 변경되지 않았음
     try {
-      // 인증번호 요청 로직
-      setIsVerificationActive(true);
-      setErrorMessage('');
+      // await requestVerificationEmail(); // 관리자 이메일로 인증번호 요청 API
+
+      // 인증번호 요청 성공 시, isVerificationActive를 토글 => 타이머 재시작!
+      setResetTimer((prev) => prev + 1); // 타이머 리셋
     } catch (error) {
-      setErrorMessage('인증번호 요청에 실패했습니다. 다시 시도해주세요.');
+      setErrorMessage('인증번호 발송에 실패했습니다.');
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const validationResult = validateCode(verificationCode); // 인증번호 유효성 검증
+
+    if (isInputDisabled) {
+      setErrorMessage('인증 시간이 만료되었습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    // if (validationResult.isValid) {
+    if (verificationCode === '123456') {
+      navigate(ROUTES.ADMIN.STRATEGY.APPROVAL); // 관리자 전략 승인 페이지로 이동
+    } else {
+      setErrorMessage(validationResult.message);
     }
   };
   return (
     <div css={containerStyle}>
       <h3 css={pageHeadingStyle}>관리자 전용</h3>
-      <VerificationInput
-        value={verificationCode}
-        onChange={setVerificationCode}
-        isActive={isVerificationActive}
-        onTimeEnd={() => {
-          setErrorMessage('인증 시간이 만료되었습니다. 다시 시도해주세요.');
-        }}
-      />
-      {errorMessage && <p>{errorMessage}</p>}
+      <form onSubmit={handleSubmit}>
+        <div css={emailVerifyContainer}>
+          <VerificationInput
+            value={verificationCode}
+            onChange={setVerificationCode}
+            resetTimer={resetTimer}
+            onTimeEnd={() => {
+              setIsInputDisabled(true); // 입력창 비활성화
+              setErrorMessage('인증 시간이 만료되었습니다. 다시 시도해주세요.');
+            }}
+            isDisabled={isInputDisabled}
+          />
+          <Button type='button' variant='accent' size='md' width={100} onClick={handleResend}>
+            재전송
+          </Button>
+        </div>
+
+        <Button
+          type='submit'
+          width={400}
+          css={buttonStyle}
+          disabled={!verificationCode || isInputDisabled}
+        >
+          확인
+        </Button>
+      </form>
+      {errorMessage && <p css={messageStyle}>{errorMessage}</p>}
     </div>
   );
 };
@@ -55,5 +113,25 @@ const pageHeadingStyle = css`
   line-height: ${theme.typography.lineHeights.md};
   font-weight: ${theme.typography.fontWeight.bold};
   margin-bottom: 32px;
+`;
+
+const emailVerifyContainer = css`
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  width: 400px;
+  margin-bottom: 12px;
+`;
+
+const buttonStyle = css`
+  margin-top: 24px;
+`;
+const messageStyle = css`
+  margin-top: 16px;
+  text-align: center;
+  color: ${theme.colors.main.alert};
+  font-size: ${theme.typography.fontSizes.caption};
+  line-height: ${theme.typography.lineHeights.sm};
 `;
 export default AdminVerifyPage;

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -58,8 +58,8 @@ const AdminVerifyPage = () => {
       return;
     }
 
-    // if (validationResult.isValid) {
-    if (verificationCode === '123456') {
+    if (validationResult.isValid) {
+      // if (verificationCode === '123456') {
       navigate(ROUTES.ADMIN.STRATEGY.APPROVAL); // 관리자 전략 승인 페이지로 이동
     } else {
       setErrorMessage(validationResult.message);

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -68,12 +68,18 @@ const AdminVerifyPage = () => {
 
     // 1. 유효성 검사 통과 여부
     // 2. 서버에서 받은 인증번호와 일치 여부
-    if (validationResult.isValid && verificationCode === serverVerificationCode) {
-      navigate(ROUTES.ADMIN.STRATEGY.APPROVAL);
-    } else if (!validationResult.isValid) {
-      setErrorMessage(validationResult.message);
+    // 조건을 단계별로 체크
+    if (validationResult.isValid) {
+      // 6자리 숫자 형식은 맞지만, 서버의 인증번호와 다른 경우
+      if (verificationCode !== serverVerificationCode) {
+        setErrorMessage('올바른 인증번호가 아닙니다.');
+      } else {
+        // 모든 조건 충족
+        navigate(ROUTES.ADMIN.STRATEGY.APPROVAL);
+      }
     } else {
-      setErrorMessage('올바른 인증번호가 아닙니다.');
+      // 6자리 숫자 형식이 아닌 경우
+      setErrorMessage(validationResult.message);
     }
   };
   return (

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -16,6 +16,12 @@ const AdminVerifyPage = () => {
   const [resetTimer, setResetTimer] = useState<number>(0); // 타이머 리셋을 위한 상태
   const [shouldReset, setShouldReset] = useState(false);
   const [isInputDisabled, setIsInputDisabled] = useState(false);
+  const [serverVerificationCode, setServerVerificationCode] = useState<string>(''); // 서버에서 받은 인증번호 저장
+
+  // 페이지 마운트 시 최초 인증번호 요청
+  useEffect(() => {
+    handleResend();
+  }, []);
 
   // 재전송 처리를 위한 useEffect
   useEffect(() => {
@@ -40,8 +46,10 @@ const AdminVerifyPage = () => {
     setShouldReset(true);
     // setState는 비동기이므로, 이 시점에서는 아직 errorMessage가 변경되지 않았음
     try {
-      // await requestVerificationEmail(); // 관리자 이메일로 인증번호 요청 API
-
+      // const response = await requestVerificationEmail();
+      // setServerVerificationCode(response.verificationCode); // 서버 응답에서 인증번호 저장
+      // 테스트용 코드
+      setServerVerificationCode('123456'); // 테스트를 위해 하드코딩
       // 인증번호 요청 성공 시, isVerificationActive를 토글 => 타이머 재시작!
       setResetTimer((prev) => prev + 1); // 타이머 리셋
     } catch (error) {
@@ -58,11 +66,14 @@ const AdminVerifyPage = () => {
       return;
     }
 
-    if (validationResult.isValid) {
-      // if (verificationCode === '123456') {
-      navigate(ROUTES.ADMIN.STRATEGY.APPROVAL); // 관리자 전략 승인 페이지로 이동
-    } else {
+    // 1. 유효성 검사 통과 여부
+    // 2. 서버에서 받은 인증번호와 일치 여부
+    if (validationResult.isValid && verificationCode === serverVerificationCode) {
+      navigate(ROUTES.ADMIN.STRATEGY.APPROVAL);
+    } else if (!validationResult.isValid) {
       setErrorMessage(validationResult.message);
+    } else {
+      setErrorMessage('올바른 인증번호가 아닙니다.');
     }
   };
   return (

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
+import tickImage from '@/assets/images/tick.svg';
 import Button from '@/components/common/Button';
 import VerificationInput from '@/components/page/signup/VerificationInput';
 import { ROUTES } from '@/constants/routes';
@@ -85,6 +86,16 @@ const AdminVerifyPage = () => {
   return (
     <div css={containerStyle}>
       <h3 css={pageHeadingStyle}>관리자 전용</h3>
+      <div css={infoStyle}>
+        <p>
+          <img src={tickImage} alt='tick' />
+          <span>관리자 전용으로 이동하기 위해서는 인증이 필요합니다</span>
+        </p>
+        <p>
+          <img src={tickImage} alt='tick' />
+          <span>가입하신 이메일로 인증번호가 전송되었습니다</span>
+        </p>
+      </div>
       <form onSubmit={handleSubmit}>
         <div css={emailVerifyContainer}>
           <VerificationInput
@@ -130,6 +141,23 @@ const pageHeadingStyle = css`
   line-height: ${theme.typography.lineHeights.md};
   font-weight: ${theme.typography.fontWeight.bold};
   margin-bottom: 32px;
+`;
+
+const infoStyle = css`
+  margin-bottom: 16px;
+  p {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 8px;
+  }
+
+  span {
+    color: ${theme.colors.gray[600]};
+    font-size: ${theme.typography.fontSizes.caption};
+    line-height: ${theme.typography.lineHeights.lg};
+    font-weight: ${theme.typography.fontWeight.medium};
+  }
 `;
 
 const emailVerifyContainer = css`

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -37,169 +37,169 @@ import StrategyListPage from '@/pages/strategy/StrategyListPage';
 import TraderDetailPage from '@/pages/trader/TraderDetailPage';
 import TraderListPage from '@/pages/trader/TraderListPage';
 
-
-export const router = createBrowserRouter([
-  {
-    path: ROUTES.HOME.PATH,
-    element: <RootLayout />,
-    errorElement: <NotFoundPage />,
-    children: [
-      {
-        path: ROUTES.HOME.PATH,
-        element: <HomePage />, // 메인 홈 페이지
-      },
-      // -------------------------------------- 인증
-      {
-        path: ROUTES.AUTH.SIGNIN,
-        element: <SignInPage />, // 로그인 페이지
-      },
-      {
-        path: ROUTES.AUTH.SIGNUP.SELECT_TYPE,
-        element: <SignUpSelectTypePage />, // 회원가입 유형 선택 페이지
-      },
-      {
-        path: ROUTES.AUTH.SIGNUP.FORM,
-        element: <SignUpFormPage />, // 회원가입 폼 페이지
-      },
-      {
-        path: ROUTES.AUTH.SIGNUP.SUCCESS,
-        element: <SignUpSuccessPage />, // 회원가입 성공 페이지
-      },
-      {
-        path: ROUTES.AUTH.ADMIN.VERIFY,
-        element: <AdminVerifyPage />, // 관리자 인증 페이지
-      },
-      {
-        path: ROUTES.AUTH.WITHDRAWAL.SUCCESS,
-        element: <WithdrawalSuccessPage />, // 회원탈퇴 성공 페이지
-      },
-      // -------------------------------------- 찾기/재설정
-      {
-        path: ROUTES.AUTH.FIND.EMAIL,
-        element: <FindEmailPage />, // 이메일 찾기 페이지
-      },
-      {
-        path: ROUTES.AUTH.FIND.EMAIL_SUCCESS,
-        element: <EmailFoundPage />, // 이메일 찾기 성공 페이지
-      },
-      {
-        path: ROUTES.AUTH.FIND.PASSWORD,
-        element: <FindPasswordPage />, // 비밀번호 찾기 페이지
-      },
-      {
-        path: ROUTES.AUTH.FIND.PASSWORD_RESET,
-        element: <ResetPasswordPage />, // 비밀번호 재설정 페이지
-      },
-      {
-        path: ROUTES.AUTH.FIND.PASSWORD_RESET_SUCCESS,
-        element: <PasswordResetSuccessPage />, // 비밀번호 재설정 성공 페이지
-      },
-      // -------------------------------------- 전략
-      {
-        path: ROUTES.STRATEGY.LIST,
-        element: <StrategyListPage />, // 전략 목록 페이지
-      },
-      {
-        path: ROUTES.STRATEGY.DETAIL(':strategyId'),
-        element: <StrategyDetailPage />, // 전략 상세 페이지
-      },
-      {
-        path: ROUTES.STRATEGY.INQUIRIES,
-        element: <InquiryPage />, // 전략 문의 페이지
-      },
-      // -------------------------------------- 트레이더
-      {
-        path: ROUTES.TRADER.LIST,
-        element: <TraderListPage />, // 트레이더 목록 페이지
-      },
-      {
-        path: ROUTES.TRADER.PROFILE(':traderId'),
-        element: <TraderDetailPage />, // 트레이더 프로필 상세 페이지
-      },
-      // -------------------------------------- 마이페이지(투자자)
-      {
-        path: ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS,
-        element: <InvestorMyPage />, // 투자자 마이페이지 - 관심전략 폴더 목록
-      },
-      {
-        path: ROUTES.MYPAGE.INVESTOR.FOLLOWING.STRATEGIES(':folderId'),
-        element: <InvestorFollowFolderPage />, // 특정 폴더의 관심전략 목록
-      },
-      {
-        path: ROUTES.MYPAGE.INVESTOR.MYINQUIRY,
-        element: <MyInquiriesPage />, // 나의 상담 게시판
-      },
-      {
-        path: ROUTES.MYPAGE.INVESTOR.PROFILE,
-        element: <InvestorProfilePage />, // 투자자 프로필 관리
-      },
-      // -------------------------------------- 마이페이지(트레이더)
-      {
-        path: ROUTES.MYPAGE.TRADER.STRATEGIES.LIST,
-        element: <TraderMyPage />, // 트레이더 마이페이지 - 나의 전략 리스트
-      },
-      {
-        path: ROUTES.MYPAGE.TRADER.STRATEGIES.CREATE,
-        element: <StrategyCreatePage />, // 전략 등록 페이지
-      },
-      {
-        path: ROUTES.MYPAGE.TRADER.STRATEGIES.EDIT(':strategyId'),
-        element: <StrategyEditPage />, // 전략 수정 페이지
-      },
-      {
-        path: ROUTES.MYPAGE.TRADER.INQUIRIES,
-        element: <InquiriesManagementPage />, // 문의 관리 페이지
-      },
-      {
-        path: ROUTES.MYPAGE.TRADER.PROFILE,
-        element: <TraderProfilePage />, // 트레이더 프로필 관리
-      },
-      // -------------------------------------- 검색
-      {
-        path: ROUTES.SEARCH.ROOT.WITH_KEYWORD(':keyword'),
-        element: <SearchTotalResultsPage />, // 통합검색결과 페이지(전략과 트레이더 검색결과)
-      },
-      {
-        path: ROUTES.SEARCH.TRADER.WITH_KEYWORD(':keyword'),
-        element: <SearchResultsInTrader />, // 트레이더 내 검색결과 페이지
-      },
-      {
-        path: ROUTES.SEARCH.STRATEGY.WITH_KEYWORD(':keyword'),
-        element: <SearchResultsInStrategy />, // 전략 내 검색결과 페이지
-      },
-    ],
-  },
-  {
-    path: ROUTES.HOME.PATH,
-    element: <AdminLayout />,
-    errorElement: <NotFoundPage />,
-    children: [
-      // -------------------------------------- 관리자
-      {
-        path: ROUTES.ADMIN.STOCK_TYPE.LIST,
-        element: <StockTypeListPage />, // 상품유형 관리 페이지(현재 대시보드 페이지)
-      },
-      {
-        path: ROUTES.ADMIN.TRADING_TYPE.LIST,
-        element: <TradingTypeListPage />, // 매매유형 관리 페이지
-      },
-      {
-        path: ROUTES.ADMIN.STRATEGY.APPROVAL,
-        element: <StrategyApprovalListPage />, // 전략 승인 관리 페이지
-      },
-    ],
-  },
-  {
-    // 404 및 기타 리다이렉트 처리
-    path: ROUTES.ERROR.NOT_FOUND,
-    element: <NotFoundPage />, // 404 Not Found 페이지
-  },
-  {
-    // 유효하지 않은 경로로 접근했을 때 404 페이지로 리다이렉트
-     path: '*',
-     element: <Navigate to={ROUTES.ERROR.NOT_FOUND} replace />,
-  },
- ],
+export const router = createBrowserRouter(
+  [
+    {
+      path: ROUTES.HOME.PATH,
+      element: <RootLayout />,
+      errorElement: <NotFoundPage />,
+      children: [
+        {
+          path: ROUTES.HOME.PATH,
+          element: <HomePage />, // 메인 홈 페이지
+        },
+        // -------------------------------------- 인증
+        {
+          path: ROUTES.AUTH.SIGNIN,
+          element: <SignInPage />, // 로그인 페이지
+        },
+        {
+          path: ROUTES.AUTH.SIGNUP.SELECT_TYPE,
+          element: <SignUpSelectTypePage />, // 회원가입 유형 선택 페이지
+        },
+        {
+          path: ROUTES.AUTH.SIGNUP.FORM,
+          element: <SignUpFormPage />, // 회원가입 폼 페이지
+        },
+        {
+          path: ROUTES.AUTH.SIGNUP.SUCCESS,
+          element: <SignUpSuccessPage />, // 회원가입 성공 페이지
+        },
+        {
+          path: ROUTES.AUTH.ADMIN.VERIFY,
+          element: <AdminVerifyPage />, // 관리자 인증 페이지
+        },
+        {
+          path: ROUTES.AUTH.WITHDRAWAL.SUCCESS,
+          element: <WithdrawalSuccessPage />, // 회원탈퇴 성공 페이지
+        },
+        // -------------------------------------- 찾기/재설정
+        {
+          path: ROUTES.AUTH.FIND.EMAIL,
+          element: <FindEmailPage />, // 이메일 찾기 페이지
+        },
+        {
+          path: ROUTES.AUTH.FIND.EMAIL_SUCCESS,
+          element: <EmailFoundPage />, // 이메일 찾기 성공 페이지
+        },
+        {
+          path: ROUTES.AUTH.FIND.PASSWORD,
+          element: <FindPasswordPage />, // 비밀번호 찾기 페이지
+        },
+        {
+          path: ROUTES.AUTH.FIND.PASSWORD_RESET,
+          element: <ResetPasswordPage />, // 비밀번호 재설정 페이지
+        },
+        {
+          path: ROUTES.AUTH.FIND.PASSWORD_RESET_SUCCESS,
+          element: <PasswordResetSuccessPage />, // 비밀번호 재설정 성공 페이지
+        },
+        // -------------------------------------- 전략
+        {
+          path: ROUTES.STRATEGY.LIST,
+          element: <StrategyListPage />, // 전략 목록 페이지
+        },
+        {
+          path: ROUTES.STRATEGY.DETAIL(':strategyId'),
+          element: <StrategyDetailPage />, // 전략 상세 페이지
+        },
+        {
+          path: ROUTES.STRATEGY.INQUIRIES,
+          element: <InquiryPage />, // 전략 문의 페이지
+        },
+        // -------------------------------------- 트레이더
+        {
+          path: ROUTES.TRADER.LIST,
+          element: <TraderListPage />, // 트레이더 목록 페이지
+        },
+        {
+          path: ROUTES.TRADER.PROFILE(':traderId'),
+          element: <TraderDetailPage />, // 트레이더 프로필 상세 페이지
+        },
+        // -------------------------------------- 마이페이지(투자자)
+        {
+          path: ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS,
+          element: <InvestorMyPage />, // 투자자 마이페이지 - 관심전략 폴더 목록
+        },
+        {
+          path: ROUTES.MYPAGE.INVESTOR.FOLLOWING.STRATEGIES(':folderId'),
+          element: <InvestorFollowFolderPage />, // 특정 폴더의 관심전략 목록
+        },
+        {
+          path: ROUTES.MYPAGE.INVESTOR.MYINQUIRY,
+          element: <MyInquiriesPage />, // 나의 상담 게시판
+        },
+        {
+          path: ROUTES.MYPAGE.INVESTOR.PROFILE,
+          element: <InvestorProfilePage />, // 투자자 프로필 관리
+        },
+        // -------------------------------------- 마이페이지(트레이더)
+        {
+          path: ROUTES.MYPAGE.TRADER.STRATEGIES.LIST,
+          element: <TraderMyPage />, // 트레이더 마이페이지 - 나의 전략 리스트
+        },
+        {
+          path: ROUTES.MYPAGE.TRADER.STRATEGIES.CREATE,
+          element: <StrategyCreatePage />, // 전략 등록 페이지
+        },
+        {
+          path: ROUTES.MYPAGE.TRADER.STRATEGIES.EDIT(':strategyId'),
+          element: <StrategyEditPage />, // 전략 수정 페이지
+        },
+        {
+          path: ROUTES.MYPAGE.TRADER.INQUIRIES,
+          element: <InquiriesManagementPage />, // 문의 관리 페이지
+        },
+        {
+          path: ROUTES.MYPAGE.TRADER.PROFILE,
+          element: <TraderProfilePage />, // 트레이더 프로필 관리
+        },
+        // -------------------------------------- 검색
+        {
+          path: ROUTES.SEARCH.ROOT.WITH_KEYWORD(':keyword'),
+          element: <SearchTotalResultsPage />, // 통합검색결과 페이지(전략과 트레이더 검색결과)
+        },
+        {
+          path: ROUTES.SEARCH.TRADER.WITH_KEYWORD(':keyword'),
+          element: <SearchResultsInTrader />, // 트레이더 내 검색결과 페이지
+        },
+        {
+          path: ROUTES.SEARCH.STRATEGY.WITH_KEYWORD(':keyword'),
+          element: <SearchResultsInStrategy />, // 전략 내 검색결과 페이지
+        },
+      ],
+    },
+    {
+      path: ROUTES.HOME.PATH,
+      element: <AdminLayout />,
+      errorElement: <NotFoundPage />,
+      children: [
+        // -------------------------------------- 관리자
+        {
+          path: ROUTES.ADMIN.STOCK_TYPE.LIST,
+          element: <StockTypeListPage />, // 상품유형 관리 페이지(현재 대시보드 페이지)
+        },
+        {
+          path: ROUTES.ADMIN.TRADING_TYPE.LIST,
+          element: <TradingTypeListPage />, // 매매유형 관리 페이지
+        },
+        {
+          path: ROUTES.ADMIN.STRATEGY.APPROVAL,
+          element: <StrategyApprovalListPage />, // 전략 승인 관리 페이지
+        },
+      ],
+    },
+    {
+      // 404 및 기타 리다이렉트 처리
+      path: ROUTES.ERROR.NOT_FOUND,
+      element: <NotFoundPage />, // 404 Not Found 페이지
+    },
+    {
+      // 유효하지 않은 경로로 접근했을 때 404 페이지로 리다이렉트
+      path: '*',
+      element: <Navigate to={ROUTES.ERROR.NOT_FOUND} replace />,
+    },
+  ],
   {
     future: {
       v7_relativeSplatPath: true,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 관리자 인증 페이지 마운트 되면 타이머 시작
- (메인페이지의 관리자인증 버튼 클릭 시 이메일인증 요청API 호출)
- 인증번호 입력되면 확인버튼 활성화
- 유효하지 않은 인증번호 입력 시 하단에 에러메시지 출력
- 이때 유효시간이 끝나면 확인버튼 비활성화 및 하단에 에러메시지 출력이 덮어씌워짐
- 타이머 종료 시간은 3분으로 설정
- 타이머 동작 중에 재전송버튼 클릭하면,
    - 타이머 재시작
    - 이메일인증 요청API 재호출
    - 하단에 재전송 완료 메시지 출력
- 유효시간 안에 인증번호 입력 후, 확인버튼 클릭하면
    - 유효성검사 성공 시, 관리자 전략승인관리 페이지로 이동
    - 유효성검사 실패 시, 하단에 에러메시지 출력

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)



https://github.com/user-attachments/assets/13c1910c-377f-449d-b1e6-c81fb3edce6a





## 📄 기타

```tsx
const response = await requestVerificationEmail(); // 인증번호 요청 API 호출
setServerVerificationCode(response.verificationCode); // 서버 응답에서 인증번호 저장
```

✅ 추가 필요한 작업: `requestVerificationEmail` 및 `setServerVerificationCode` 로직 구현/테스트

## Sourcery에 의한 요약

타이머와 인증 코드 처리를 포함한 관리자 인증 페이지 UI를 구현합니다. 페이지가 마운트될 때 타이머를 시작하고, 타이머를 재설정하여 코드를 다시 보낼 수 있는 기능을 도입하며, 코드를 검증하여 관리자 전략 승인 페이지로 이동합니다. 잘못된 코드와 만료된 인증 시간에 대한 오류 처리를 강화합니다.

새로운 기능:
- 관리자 인증 페이지가 마운트될 때 타이머를 구현하여 코드 입력을 위한 3분 카운트다운을 시작합니다.
- 재전송 버튼을 활성화하여 타이머를 재시작하고 인증 코드를 다시 보내며, 완료 시 성공 메시지를 표시합니다.
- 인증 코드가 입력되면 제출 버튼을 활성화하고, 성공적인 검증 후 관리자 전략 승인 페이지로 이동합니다.

개선 사항:
- 잘못된 인증 코드가 입력되거나 인증 시간이 만료되었을 때 오류 메시지를 표시하여 오류 처리를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement the admin verification page UI with a timer and verification code handling. Introduce features to start a timer upon page mount, enable code resending with timer reset, and validate the code to navigate to the admin strategy approval page. Enhance error handling for invalid codes and expired verification time.

New Features:
- Implement a timer that starts when the admin verification page is mounted, with a 3-minute countdown for code entry.
- Enable the resend button to restart the timer and resend the verification code, displaying a success message upon completion.
- Activate the submit button when a verification code is entered, and navigate to the admin strategy approval page upon successful validation.

Enhancements:
- Improve error handling by displaying error messages when an invalid verification code is entered or when the verification time expires.

</details>