### PR TITLE
[design]매매유형 관리 페이지 퍼블리싱 (#107)

### DIFF
--- a/src/components/page/admin/TypeTable.tsx
+++ b/src/components/page/admin/TypeTable.tsx
@@ -6,7 +6,8 @@ import Button from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
 import theme from '@/styles/theme';
 
-interface TypeTableProps {
+export interface TypeTableProps {
+  id: number;
   icon: string;
   title: string;
 }
@@ -18,9 +19,10 @@ interface AttributeProps {
 interface DataProps {
   attributes: AttributeProps[];
   data: TypeTableProps[];
+  onSelectChange: (selectedIdx: number[]) => void;
 }
 
-const TypeTable = ({ attributes, data }: DataProps) => {
+const TypeTable = ({ attributes, data, onSelectChange }: DataProps) => {
   const [selected, setSelected] = useState<boolean[]>(new Array(data.length).fill(false));
   const [selectAll, setSelectAll] = useState(false);
 
@@ -28,6 +30,8 @@ const TypeTable = ({ attributes, data }: DataProps) => {
     const newSelectAll = !selectAll;
     setSelectAll(newSelectAll);
     setSelected(new Array(data.length).fill(newSelectAll));
+    const selectIdx = newSelectAll ? data.map((item) => item.id) : [];
+    onSelectChange(selectIdx);
   };
 
   const handleSelect = (idx: number) => {
@@ -35,7 +39,10 @@ const TypeTable = ({ attributes, data }: DataProps) => {
     updatedSelected[idx] = !updatedSelected[idx];
     setSelected(updatedSelected);
 
+    const selectedIds = data.filter((_, index) => updatedSelected[index]).map((item) => item.id);
+
     setSelectAll(updatedSelected.every(Boolean));
+    onSelectChange(selectedIds);
   };
 
   return (

--- a/src/pages/admin/stock-type/StockTypeListPage.tsx
+++ b/src/pages/admin/stock-type/StockTypeListPage.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
@@ -6,30 +8,37 @@ import theme from '@/styles/theme';
 
 const mockStock = [
   {
+    id: 1,
     title: '국내주식',
     icon: '/DomestiicStocks.svg',
   },
   {
+    id: 2,
     title: '해외주식',
     icon: '/logo.svg',
   },
   {
+    id: 3,
     title: '국내선물',
     icon: '/logo.svg',
   },
   {
+    id: 4,
     title: '내선물도',
     icon: '/logo.svg',
   },
   {
+    id: 5,
     title: '주셈',
     icon: '/logo.svg',
   },
   {
+    id: 6,
     title: '해외ETF',
     icon: '/logo.svg',
   },
   {
+    id: 7,
     title: '국내ETF',
     icon: '/logo.svg',
   },
@@ -47,22 +56,33 @@ const stockAttributes = [
   },
 ];
 
-const StockTypeListPage = () => (
-  <div css={stockStyle}>
-    <div css={headingStyle}>
-      <div css={titleStyle}>상품유형 관리</div>
-      <div css={buttonArea}>
-        <Button size='xs' width={89}>
-          등록
-        </Button>
-        <Button variant='neutral' size='xs' width={89}>
-          삭제
-        </Button>
+const StockTypeListPage = () => {
+  const [setStock, setSelectedStocks] = useState<number[]>([]);
+
+  const handleSelectChange = (selectedIdx: number[]) => {
+    setSelectedStocks(selectedIdx);
+  };
+  return (
+    <div css={stockStyle}>
+      <div css={headingStyle}>
+        <div css={titleStyle}>상품유형 관리</div>
+        <div css={buttonArea}>
+          <Button size='xs' width={89}>
+            등록
+          </Button>
+          <Button variant='neutral' size='xs' width={89}>
+            삭제
+          </Button>
+        </div>
       </div>
+      <TypeTable
+        attributes={stockAttributes}
+        data={mockStock}
+        onSelectChange={handleSelectChange}
+      />
     </div>
-    <TypeTable attributes={stockAttributes} data={mockStock} />
-  </div>
-);
+  );
+};
 
 const stockStyle = css`
   display: flex;

--- a/src/pages/admin/stock-type/StockTypeListPage.tsx
+++ b/src/pages/admin/stock-type/StockTypeListPage.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
 import TypeTable from '@/components/page/admin/TypeTable';
+import useModalStore from '@/stores/modalStore';
 import theme from '@/styles/theme';
 
 const mockStock = [
@@ -57,11 +59,37 @@ const stockAttributes = [
 ];
 
 const StockTypeListPage = () => {
-  const [setStock, setSelectedStocks] = useState<number[]>([]);
+  const [selectedStocks, setSelectedStocks] = useState<number[]>([]);
+  const [mockStocks, setMockStocks] = useState(mockStock);
+  const { openModal } = useModalStore();
 
   const handleSelectChange = (selectedIdx: number[]) => {
     setSelectedStocks(selectedIdx);
   };
+
+  const handleDelete = () => {
+    if (selectedStocks.length > 0) {
+      openModal({
+        type: 'warning',
+        title: '이미지 삭제',
+        desc: `선택하신 ${selectedStocks.length}개의 유형을 삭제하시겠습니까?`,
+        onAction: () => {
+          setMockStocks((prevItems) =>
+            prevItems.filter((item) => !selectedStocks.includes(item.id))
+          );
+          setSelectedStocks([]);
+        },
+      });
+    } else {
+      openModal({
+        type: 'warning',
+        title: '알림',
+        desc: `선택 된 항목이 없습니다.`,
+        onAction: () => {},
+      });
+    }
+  };
+
   return (
     <div css={stockStyle}>
       <div css={headingStyle}>
@@ -70,16 +98,17 @@ const StockTypeListPage = () => {
           <Button size='xs' width={89}>
             등록
           </Button>
-          <Button variant='neutral' size='xs' width={89}>
+          <Button variant='neutral' size='xs' width={89} onClick={handleDelete}>
             삭제
           </Button>
         </div>
       </div>
       <TypeTable
         attributes={stockAttributes}
-        data={mockStock}
+        data={mockStocks}
         onSelectChange={handleSelectChange}
       />
+      <Modal />
     </div>
   );
 };

--- a/src/pages/admin/trading-type/TradingTypeListPage.tsx
+++ b/src/pages/admin/trading-type/TradingTypeListPage.tsx
@@ -1,7 +1,181 @@
-const TradingTypeListPage = () => (
-  <div>
-    <h1>매매유형 관리 페이지</h1>
-  </div>
-);
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import Pagination from '@/components/common/Pagination';
+import TypeTable, { TypeTableProps } from '@/components/page/admin/TypeTable';
+import useModalStore from '@/stores/modalStore';
+import theme from '@/styles/theme';
+
+const mockTradeItems = [
+  {
+    id: 1,
+    title: '자동',
+    icon: '/logo.svg',
+  },
+  {
+    id: 2,
+    title: '반자동(하이브리드)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 3,
+    title: '수동(메뉴얼)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 4,
+    title: '자동',
+    icon: '/logo.svg',
+  },
+  {
+    id: 5,
+    title: '반자동(하이브리드)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 6,
+    title: '수동(메뉴얼)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 7,
+    title: '자동',
+    icon: '/logo.svg',
+  },
+  {
+    id: 8,
+    title: '반자동(하이브리드)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 9,
+    title: '수동(메뉴얼)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 10,
+    title: '자동',
+    icon: '/logo.svg',
+  },
+  {
+    id: 11,
+    title: '반자동(하이브리드)',
+    icon: '/logo.svg',
+  },
+  {
+    id: 12,
+    title: '수동(메뉴얼)',
+    icon: '/logo.svg',
+  },
+];
+
+const tradeAttributes = [
+  {
+    item: '아이콘',
+  },
+  {
+    item: '매매유형',
+  },
+  {
+    item: '유형관리',
+  },
+];
+
+const paginatedData = (data: TypeTableProps[], currentPage: number, pageSize: number) => {
+  const startIdx = (currentPage - 1) * pageSize;
+  const endIdx = startIdx + pageSize;
+  return data.slice(startIdx, endIdx);
+};
+
+const TradingTypeListPage = () => {
+  const limit = 10;
+  const [page, setPage] = useState(1);
+  const [mockTrade, setMockTrade] = useState(mockTradeItems);
+  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const { openModal } = useModalStore();
+
+  const handleSelectChange = (selectedIdx: number[]) => {
+    setSelectedItems(selectedIdx);
+  };
+
+  const handleDelete = () => {
+    if (selectedItems.length > 0) {
+      openModal({
+        type: 'warning',
+        title: '이미지 삭제',
+        desc: `선택하신 ${selectedItems.length}개의 유형을 삭제하시겠습니까?`,
+        onAction: () => {
+          setMockTrade((prevItems) => prevItems.filter((item) => !selectedItems.includes(item.id)));
+          setSelectedItems([]);
+        },
+      });
+    } else {
+      openModal({
+        type: 'warning',
+        title: '알림',
+        desc: `선택 된 항목이 없습니다.`,
+        onAction: () => {},
+      });
+    }
+  };
+
+  return (
+    <div css={tradeStyle}>
+      <div css={headingStyle}>
+        <div css={titleStyle}>매매유형 관리</div>
+        <div css={buttonArea}>
+          <Button size='xs' width={89}>
+            등록
+          </Button>
+          <Button variant='neutral' size='xs' width={89} onClick={handleDelete}>
+            삭제
+          </Button>
+        </div>
+      </div>
+      <TypeTable
+        attributes={tradeAttributes}
+        data={paginatedData(mockTrade, page, limit)}
+        onSelectChange={handleSelectChange}
+      />
+      <Pagination
+        totalPage={Math.ceil(mockTrade.length / limit)}
+        limit={limit}
+        page={page}
+        setPage={setPage}
+      />
+      <Modal />
+    </div>
+  );
+};
+const tradeStyle = css`
+  display: flex;
+  width: 955px;
+  padding: 48px 40px 80px 40px;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  background-color: ${theme.colors.main.white};
+  border-radius: 8px;
+`;
+
+const headingStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+const titleStyle = css`
+  ${theme.textStyle.headings.h3};
+  color: ${theme.colors.gray[700]};
+`;
+
+const buttonArea = css`
+  display: flex;
+  gap: 8px;
+`;
 
 export default TradingTypeListPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

매매유형 관리 페이지 퍼블리싱

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![스크린샷 2024-11-18 오전 10 33 41](https://github.com/user-attachments/assets/7b36720b-91ae-48c5-8e13-434232fbcb97)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

항목 선택, 삭제 및 페이지 매김 기능을 갖춘 거래 유형 관리 페이지를 게시하고, 이러한 기능을 지원하도록 TypeTable 구성 요소를 개선합니다.

새로운 기능:
- 항목 선택, 삭제 및 페이지 매김과 같은 기능을 갖춘 완전한 기능의 거래 유형 관리 페이지 구현.

개선 사항:
- 항목 선택 및 삭제 기능을 지원하도록 TypeTable 구성 요소를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Publish the trading type management page with item selection, deletion, and pagination features, and enhance the TypeTable component to support these functionalities.

New Features:
- Implement a fully functional trading type management page with features like item selection, deletion, and pagination.

Enhancements:
- Enhance the TypeTable component to support item selection and deletion functionality.

</details>