### PR TITLE
[Fix] 페이지 렌더링 시에만 카운트 다운이 따닥으로 감소하는 문제 해결

### DIFF
--- a/src/components/page/signup/VerificationInput.tsx
+++ b/src/components/page/signup/VerificationInput.tsx
@@ -24,7 +24,7 @@ const VerificationInput = ({
   isDisabled = false, // 기본값 false
   startTimer = true, // 기본값 true
 }: VerificationInputProps) => {
-  const [timeLeft, setTimeLeft] = useState<number>(8); // 초기값 3분  => 179초
+  const [timeLeft, setTimeLeft] = useState<number>(179); // 초기값 3분  => 179초
   const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null); // 타이머 id
   const [showTimer, setShowTimer] = useState(false); // 타이머 보이기 여부
   const [isTimerExpired, setIsTimerExpired] = useState(false); // 타이머 만료 상태 추가
@@ -35,7 +35,7 @@ const VerificationInput = ({
     if (intervalId) {
       clearInterval(intervalId);
     }
-    setTimeLeft(8); // 타이머 초기화
+    setTimeLeft(179); // 타이머 초기화
     setShowTimer(true); // 타이머 시작할 때 보이기
     setIsTimerExpired(false); // 타이머 시작할 때 만료 상태 초기화
 
@@ -76,7 +76,7 @@ const VerificationInput = ({
       }
       // 타이머가 만료된 상태가 아닐 때만 타이머를 숨김
       if (!isTimerExpired) {
-        setTimeLeft(8);
+        setTimeLeft(179);
         setShowTimer(false);
       }
     }

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -34,7 +34,7 @@ const SignInPage: React.FC = () => (
         <Link to={ROUTES.AUTH.FIND.PASSWORD}>비밀번호 찾기</Link>
       </li>
       <li>
-        <Link to={ROUTES.AUTH.SIGNUP.FORM}>회원가입</Link>
+        <Link to={ROUTES.AUTH.SIGNUP.SELECT_TYPE}>회원가입</Link>
       </li>
     </ul>
   </div>

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -15,24 +15,14 @@ const AdminVerifyPage = () => {
   const [verificationCode, setVerificationCode] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [resetTimer, setResetTimer] = useState<number>(0); // 타이머 리셋을 위한 상태
-  const [shouldReset, setShouldReset] = useState(false);
   const [isInputDisabled, setIsInputDisabled] = useState(false);
   const [serverVerificationCode, setServerVerificationCode] = useState<string>(''); // 서버에서 받은 인증번호 저장
+  const [isVerificationRequested, setIsVerificationRequested] = useState(false); // 추가된 상태
 
   // 페이지 마운트 시 최초 인증번호 요청
   useEffect(() => {
     handleResend();
   }, []);
-
-  // 재전송 처리를 위한 useEffect
-  useEffect(() => {
-    if (shouldReset) {
-      setErrorMessage('');
-      setResetTimer((prev) => prev + 1);
-      setIsInputDisabled(false); // 입력창 활성화
-      setShouldReset(false);
-    }
-  }, [shouldReset]);
 
   // verificationCode가 변경될 때마다 실행
   useEffect(() => {
@@ -42,17 +32,20 @@ const AdminVerifyPage = () => {
     }
   }, [verificationCode]);
 
-  // 인증번호 재요청
+  // 인증번호 요청/재요청
   const handleResend = () => {
-    setShouldReset(true);
     // setState는 비동기이므로, 이 시점에서는 아직 errorMessage가 변경되지 않았음
     try {
       // const response = await requestVerificationEmail();
       // setServerVerificationCode(response.verificationCode); // 서버 응답에서 인증번호 저장
       // 테스트용 코드
       setServerVerificationCode('123456'); // 테스트를 위해 하드코딩
+      setIsVerificationRequested(true); // 인증 요청 상태 활성화
       // 인증번호 요청 성공 시, isVerificationActive를 토글 => 타이머 재시작!
       setResetTimer((prev) => prev + 1); // 타이머 리셋
+      setIsInputDisabled(false);
+      setErrorMessage('');
+      setVerificationCode('');
     } catch (error) {
       setErrorMessage('인증번호 발송에 실패했습니다.');
     }
@@ -102,8 +95,10 @@ const AdminVerifyPage = () => {
             value={verificationCode}
             onChange={setVerificationCode}
             resetTimer={resetTimer}
+            startTimer={isVerificationRequested} // startTimer prop 추가
             onTimeEnd={() => {
               setIsInputDisabled(true); // 입력창 비활성화
+              setIsVerificationRequested(false); // 타이머 종료 시 인증 요청 상태도 false로
               setErrorMessage('인증 시간이 만료되었습니다. 다시 시도해주세요.');
             }}
             isDisabled={isInputDisabled}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 불필요한 shouldReset 상태와 관련 useEffect 제거
- isVerificationRequested 상태 추가 및 활용
- handleResend 함수 단순화
- VerificationInput에 startTimer prop 전달
- VerificationInput 타이머 시간 3분으로 변경

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

불필요한 상태를 제거하고 재전송 로직을 단순화하여 카운트다운 타이머 문제를 수정합니다. 인증 요청을 관리하기 위한 새로운 상태를 추가하고 타이머 지속 시간을 3분으로 업데이트합니다.

버그 수정:
- 페이지가 렌더링될 때 카운트다운 타이머가 두 번 감소하는 문제를 수정합니다.

개선 사항:
- `handleResend` 함수를 단순화하고 불필요한 상태 관리를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the countdown timer issue by removing unnecessary state and simplifying the resend logic. Add a new state to manage verification requests and update the timer duration to 3 minutes.

Bug Fixes:
- Fix the issue where the countdown timer decreases twice when the page is rendered.

Enhancements:
- Simplify the handleResend function and remove unnecessary state management.

</details>