### PR TITLE
[Setting, Refactor] API와 MSW production 세팅

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,8 +8,8 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.6.4'
-const INTEGRITY_CHECKSUM = 'ca7800994cc8bfb5eb961e037c877074'
+const PACKAGE_VERSION = '2.6.0'
+const INTEGRITY_CHECKSUM = '07a8241b182f8a246a7cd39894799a9e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -192,14 +192,12 @@ async function getResponse(event, client, requestId) {
   const requestClone = request.clone()
 
   function passthrough() {
-    // Cast the request headers to a new Headers instance
-    // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers)
+    const headers = Object.fromEntries(requestClone.headers.entries())
 
-    // Remove the "accept" header value that marked this request as passthrough.
-    // This prevents request alteration and also keeps it compliant with the
-    // user-defined CORS policies.
-    headers.delete('accept', 'msw/passthrough')
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
 
     return fetch(requestClone, { headers })
   }

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -5,3 +5,11 @@ export const API_BASE_URL = import.meta.env.VITE_BASE_URL;
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
 });
+
+// TODO: 요청 인터셉터 구현
+// - 요청 URL과 메서드 로깅 (디버깅용)
+// - Authorization 헤더에 로그인 토큰 추가 (localStorage or sessionStorage에서 가져오기)
+
+// TODO: 응답 인터셉터 구현
+// - 응답 데이터를 호출부에서 쉽게 처리할 수 있도록 변환
+// - 상태 코드 기반 에러 처리 추가 (401 Unauthorized, 404 Not Found 등)

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export const API_BASE_URL = import.meta.env.VITE_BASE_URL;
+
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+});

--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -1,0 +1,3 @@
+export const API_ENDPOINTS = {
+  NOTICES: '/api/notices',
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,15 +8,18 @@ import App from './App.tsx';
 import GlobalStyle from '@/styles/GlobalStyle';
 import theme from '@/styles/theme';
 
-const initMocks = async (): Promise<void> => {
-  if (process.env.NODE_ENV === 'development') {
+const initMocks = async () => {
+  if (import.meta.env.VITE_ENABLE_MSW === 'true') {
     const { worker } = await import('./mocks/browser');
     await worker.start({
       onUnhandledRequest: 'bypass',
     });
+    console.log('[MSW] Mock Service Worker is running.');
+  } else {
+    console.log('[MSW] Mock Service Worker is disabled.');
   }
-  return Promise.resolve();
 };
+
 const rootElement = document.getElementById('root');
 
 if (!rootElement) {

--- a/src/mocks/handlers/example.handlers.ts
+++ b/src/mocks/handlers/example.handlers.ts
@@ -1,0 +1,7 @@
+import { http, HttpResponse } from 'msw';
+
+export const exampleHandlers = [
+  http.get('/mock/api/example', async () =>
+    HttpResponse.json({ message: 'This is a mocked response!' }, { status: 200 })
+  ),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { authHandlers } from '@/mocks/handlers/auth.handlers';
+import { exampleHandlers } from '@/mocks/handlers/example.handlers';
 import { strategyHandlers } from '@/mocks/handlers/strategy.handlers';
 
-export const handlers = [...authHandlers, ...strategyHandlers];
+export const handlers = [...authHandlers, ...strategyHandlers, ...exampleHandlers];

--- a/src/mocks/mockEndpoints.ts
+++ b/src/mocks/mockEndpoints.ts
@@ -1,0 +1,3 @@
+export const MOCK_API_ENDPOINTS = {
+  EXAMPLE: '/mock/api/example',
+};

--- a/src/pages/mypage/trader/TraderMyPage.tsx
+++ b/src/pages/mypage/trader/TraderMyPage.tsx
@@ -1,12 +1,12 @@
-import InputTestPage from '@/pages/test-page/InputTestPage';
-import PaginationTestPage from '@/pages/test-page/PaginationTestPage';
+import APITestPage from '@/pages/test-page/APITestPage';
+import MswTestPage from '@/pages/test-page/MockTestPage';
 
 const TraderMyPage = () => (
   <div>
     <h1>나의 전략 리스트</h1>
     <p>트레이더가 마이페이지로 이동했을 때 나타나는 페이지입니다.</p>
-    <InputTestPage />
-    <PaginationTestPage />
+    <MswTestPage />
+    <APITestPage />
   </div>
 );
 

--- a/src/pages/test-page/APITestPage.tsx
+++ b/src/pages/test-page/APITestPage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+import { API_BASE_URL, apiClient } from '@/api/apiClient';
+import { API_ENDPOINTS } from '@/api/apiEndpoints';
+
+interface Notice {
+  id: number;
+  noticeStatus: string;
+  title: string;
+  content: string;
+  postedAt: string;
+  updatedAt: string;
+  scheduledAt: string;
+  viewCount: number;
+  writerId: number;
+}
+
+interface Sort {
+  sorted: boolean;
+  empty: boolean;
+  unsorted: boolean;
+}
+
+interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: Sort;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}
+
+interface NoticeResponse {
+  content: Notice[];
+  pageable: Pageable;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+  size: number;
+  number: number;
+  sort: Sort;
+  numberOfElements: number;
+  first: boolean;
+  empty: boolean;
+}
+
+const initialNoticeResponse: NoticeResponse = {
+  content: [],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 10,
+    sort: {
+      sorted: false,
+      empty: true,
+      unsorted: true,
+    },
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  totalElements: 0,
+  totalPages: 0,
+  last: true,
+  size: 10,
+  number: 0,
+  sort: {
+    sorted: false,
+    empty: true,
+    unsorted: true,
+  },
+  numberOfElements: 0,
+  first: true,
+  empty: true,
+};
+
+const APITestPage = () => {
+  const [notices, setNotices] = useState<NoticeResponse>(initialNoticeResponse);
+  const [, setError] = useState('');
+
+  useEffect(() => {
+    const fetchNotices = async () => {
+      try {
+        console.log('API_BASE_URL:', API_BASE_URL);
+        console.log('apiClient baseURL:', apiClient.defaults.baseURL);
+
+        const response = await apiClient.get(API_ENDPOINTS.NOTICES);
+        const data = await response.data;
+        setNotices(data);
+
+        console.log('Response status:', response.status);
+        console.log('API Response:', data);
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          setError(error.response?.data?.message || 'An error occurred while fetching notices');
+        } else {
+          setError('An unknown error occurred');
+        }
+        console.error('Failed to fetch notices:', error);
+      }
+    };
+
+    fetchNotices();
+  }, []);
+
+  return (
+    <div>
+      <br></br>
+      <p>-----------------</p>
+      <h1>아래는 api 백엔드 연결</h1>
+      {notices ? (
+        <ul>
+          <li>Total Elements: {notices.totalElements}</li>
+          <li>Total Pages: {notices.totalPages}</li>
+          <li>Is First Page: {notices.first ? 'Yes' : 'No'}</li>
+          <li>Is Last Page: {notices.last ? 'Yes' : 'No'}</li>
+          <li>Is Empty: {notices.empty ? 'Yes' : 'No'}</li>
+        </ul>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+};
+
+export default APITestPage;

--- a/src/pages/test-page/MockTestPage.tsx
+++ b/src/pages/test-page/MockTestPage.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+import { MOCK_API_ENDPOINTS } from '@/mocks/mockEndpoints';
+
+const MockTestPage = () => {
+  const [mockData, setMockData] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMockData = async () => {
+      try {
+        const response = await axios.get(MOCK_API_ENDPOINTS.EXAMPLE);
+        setMockData(response.data.message);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchMockData();
+  }, []);
+
+  return (
+    <div>
+      <h1>MSW Example</h1>
+      {mockData ? <p>Response: {mockData}</p> : <p>Loading...</p>}
+    </div>
+  );
+};
+
+export default MockTestPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #130 

## 📋 작업 내용

1. API와 Mock 엔드포인트를 각각 별도의 폴더에 정리해 두었습니다. 처음에는 constants 폴더에 넣는 것을 고려했지만, 의미적으로 API와 Mock 엔드포인트를 분리하는 것이 더 직관적이고 쉽게 찾을 수 있을 것 같아 현재와 같이 구성했습니다.

2. MSW 활성화 조건을 import.meta.env.VITE_ENABLE_MSW === 'true'로 설정해 두었습니다. 
  그 이유는 Vite가 Node.js 환경에서 동작하는 일반적인 환경 변수 시스템을 직접적으로 지원하지 않기 때문입니다. 대신 Vite는 브라우저 환경에서도 동작 가능한 import.meta.env를 제공합니다. 
  MSW 활성화를 제어하기 위해 각 환경에 맞는 .env 파일을 생성하고, VITE_ENABLE_MSW 값을 설정해 관리하는 방식이 더 적합하다고 판단했습니다. 참고로, import.meta.env.PROD도 사용할 수 있지만, 개발 및 테스트 환경에서도 유연하게 제어하기 위해 VITE_ENABLE_MSW를 활용하는 방법을 선택했습니다.

3. apiClient에 인터셉터를 설정해 두었습니다. 인터셉터를 통해 각 요청마다 토큰 값이나 Content-Type 헤더를 반복적으로 설정하지 않아도 되도록 구성했습니다. 주석으로 인터셉터 동작을 명시해 두었으니 필요에 따라 쉽게 수정하거나 활성화할 수 있습니다.


## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="1899" alt="스크린샷 2024-11-18 오후 11 02 08" src="https://github.com/user-attachments/assets/4bcf78b4-b2f4-439e-aeaf-576c7b5d0023">


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

API 및 모의 테스트를 위한 새로운 테스트 페이지를 추가하고, 환경 변수를 통해 구성할 수 있도록 모의 서비스 워커 설정을 개선합니다.

새로운 기능:
- 백엔드에서 공지를 가져와 표시하는 새로운 API 테스트 페이지를 도입합니다.
- API 모킹을 위한 Mock Service Worker (MSW)의 사용을 보여주는 모의 테스트 페이지를 추가합니다.

개선 사항:
- 환경 변수에 의해 제어되도록 모의 서비스 워커 초기화를 업데이트하여 구성에 따라 활성화 또는 비활성화할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new test pages for API and mock testing, and enhance the mock service worker setup to be configurable via environment variables.

New Features:
- Introduce a new API test page to fetch and display notices from the backend.
- Add a mock test page to demonstrate the use of Mock Service Worker (MSW) for API mocking.

Enhancements:
- Update the mock service worker initialization to be controlled by an environment variable, allowing it to be enabled or disabled based on configuration.

</details>