### PR TITLE
[Design] 투자자 마이페이지 - 나의 문의 CSS

### DIFF
--- a/src/components/navigation/InvestorMypageNav.tsx
+++ b/src/components/navigation/InvestorMypageNav.tsx
@@ -22,7 +22,7 @@ const InvestorMypageNav = () => (
           <Link to={`${ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS}`}>
             <li css={navMenu}>나의 관심 전략</li>
           </Link>
-          <Link to={`${ROUTES.MYPAGE.INVESTOR.MYINQUIRY}`}>
+          <Link to={`${ROUTES.MYPAGE.INVESTOR.MYINQUIRY.LIST}`}>
             <li css={navMenu}>나의 문의</li>
           </Link>
           <Link to={`${ROUTES.MYPAGE.INVESTOR.PROFILE}`}>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -46,7 +46,10 @@ export const ROUTES = {
         FOLDERS: '/mypage/investor', // 관심전략 폴더 목록 (투자자 마이페이지 첫 화면)
         STRATEGIES: (folderId: string) => `/mypage/investor/following/${folderId}`, // 특정 폴더의 관심전략 목록
       },
-      MYINQUIRY: '/mypage/investor/myinquiry', // 나의 상담 게시판
+      MYINQUIRY: {
+        LIST: '/mypage/investor/myinquiry', // 나의 상담 게시판
+        DETAIL: (inquiryId: string) => `/mypage/investor/myinquiry/${inquiryId}`,
+      },
       PROFILE: '/mypage/investor/profile', // 프로필 관리
     },
     TRADER: {

--- a/src/pages/mypage/investor/MyInquiresDetailPage.tsx
+++ b/src/pages/mypage/investor/MyInquiresDetailPage.tsx
@@ -1,0 +1,3 @@
+const MyInquiresDetailPage = () => <div>MyInquiresDetailPage</div>;
+
+export default MyInquiresDetailPage;

--- a/src/pages/mypage/investor/MyInquiriesPage.tsx
+++ b/src/pages/mypage/investor/MyInquiriesPage.tsx
@@ -1,7 +1,244 @@
+import { css } from '@emotion/react';
+import { Link } from 'react-router-dom';
+
+import Pagination from '@/components/common/Pagination';
+import { ROUTES } from '@/constants/routes';
+import theme from '@/styles/theme';
+
+const myInquirie = [
+  {
+    id: 1,
+    inqurieTitle: '이거 믿을만한 전략인가요?',
+    profileImg: 'https://i.pinimg.com/736x/56/cd/db/56cddb00efcd9cec66ce5474092f3328.jpg',
+    nickName: '내가여기서투자짱',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 2,
+    inqurieTitle: '안녕하세요. 이 전략에 대해 궁금한 점이 있어 문의드립니다. 어쩌구저쩌구',
+    profileImg: 'https://i.pinimg.com/474x/f5/56/15/f55615edf4217032bea9ce9cb6242053.jpg',
+    nickName: '저희닉네임길이제한이얼마나있을까요?',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 3,
+    inqurieTitle: '이거 제안서가 이상한데 자세히 설명 가능할까요?',
+    profileImg: 'https://i.pinimg.com/474x/6f/6d/ff/6f6dffbfa8c99f4963f5c4b0d814ae22.jpg',
+    nickName: 'imnotningning',
+    inqurieStatus: '완료',
+    date: '2024.11.16',
+  },
+  {
+    id: 4,
+    inqurieTitle: '이거 믿을만한 전략인가요?',
+    profileImg: 'https://i.pinimg.com/736x/56/cd/db/56cddb00efcd9cec66ce5474092f3328.jpg',
+    nickName: '내가여기서투자짱',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 5,
+    inqurieTitle: '안녕하세요. 이 전략에 대해 궁금한 점이 있어 문의드립니다. 어쩌구저쩌구',
+    profileImg: 'https://i.pinimg.com/474x/f5/56/15/f55615edf4217032bea9ce9cb6242053.jpg',
+    nickName: '저희닉네임길이제한이얼마나있을까요?',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 6,
+    inqurieTitle: '이거 제안서가 이상한데 자세히 설명 가능할까요?',
+    profileImg: 'https://i.pinimg.com/474x/6f/6d/ff/6f6dffbfa8c99f4963f5c4b0d814ae22.jpg',
+    nickName: 'imnotningning',
+    inqurieStatus: '완료',
+    date: '2024.11.16',
+  },
+  {
+    id: 7,
+    inqurieTitle: '이거 믿을만한 전략인가요?',
+    profileImg: 'https://i.pinimg.com/736x/56/cd/db/56cddb00efcd9cec66ce5474092f3328.jpg',
+    nickName: '내가여기서투자짱',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 8,
+    inqurieTitle: '안녕하세요. 이 전략에 대해 궁금한 점이 있어 문의드립니다. 어쩌구저쩌구',
+    profileImg: 'https://i.pinimg.com/474x/f5/56/15/f55615edf4217032bea9ce9cb6242053.jpg',
+    nickName: '저희닉네임길이제한이얼마나있을까요?',
+    inqurieStatus: '대기',
+    date: '2024.11.16',
+  },
+  {
+    id: 9,
+    inqurieTitle: '이거 제안서가 이상한데 자세히 설명 가능할까요?',
+    profileImg: 'https://i.pinimg.com/474x/6f/6d/ff/6f6dffbfa8c99f4963f5c4b0d814ae22.jpg',
+    nickName: 'imnotningning',
+    inqurieStatus: '완료',
+    date: '2024.11.16',
+  },
+  {
+    id: 10,
+    inqurieTitle: '이거 제안서가 이상한데 자세히 설명 가능할까요?',
+    profileImg: 'https://i.pinimg.com/474x/6f/6d/ff/6f6dffbfa8c99f4963f5c4b0d814ae22.jpg',
+    nickName: 'imnotningning',
+    inqurieStatus: '완료',
+    date: '2024.11.16',
+  },
+];
+
 const MyInquiriesPage = () => (
-  <div>
-    <h1>나의 문의</h1>
-    <p>나의 문의 내역을 확인할 수 있는 페이지입니다.</p>
+  <div css={investorMypageWrapper}>
+    <div css={titleWrapper}>
+      <h1>나의 문의</h1>
+      <span>
+        총 <strong>50</strong>개의 문의 내역이 있습니다.
+      </span>
+    </div>
+    <div css={tableWrapper}>
+      <div css={headerStyle}>
+        <div>제목</div>
+        <div>트레이더</div>
+        <div>답변상태</div>
+        <div>날짜</div>
+      </div>
+      {myInquirie.map((inquirie) => (
+        <Link
+          to={`${ROUTES.MYPAGE.INVESTOR.MYINQUIRY.DETAIL(inquirie.id.toString())}`}
+          key={inquirie.id}
+        >
+          <div css={rowStyle}>
+            <div css={inquirieTitleStyle}>
+              <span>Q.</span>
+              <div>{inquirie.inqurieTitle}</div>
+            </div>
+            <div css={traderInfoStyle}>
+              <img src={inquirie.profileImg} alt='' />
+              <span>{inquirie.nickName}</span>
+            </div>
+            <div css={statusStyle(inquirie.inqurieStatus)}>
+              {inquirie.inqurieStatus === '대기' && <span className='dot' />}
+              {inquirie.inqurieStatus}
+            </div>
+            <div>{inquirie.date}</div>
+          </div>
+        </Link>
+      ))}
+    </div>
+    <Pagination totalPage={5} limit={10} page={1} setPage={1} />
   </div>
 );
+
+const investorMypageWrapper = css`
+  display: flex;
+  flex-direction: column;
+  width: 955px;
+  padding: 48px 40px 80px 40px;
+  background-color: ${theme.colors.main.white};
+  border-radius: 8px;
+`;
+
+const titleWrapper = css`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 32px;
+  color: ${theme.colors.gray[700]};
+
+  h1 {
+    font-size: 34px;
+    font-weight: 700;
+    line-height: 140%;
+  }
+
+  span {
+    font-weight: 400;
+
+    strong {
+      color: ${theme.colors.main.primary};
+    }
+  }
+`;
+
+const tableWrapper = css`
+  margin-bottom: 56px;
+`;
+
+const rowStyle = css`
+  display: grid;
+  grid-template-columns: 415px 200px 140px 120px;
+  align-items: center;
+  height: 90px;
+  background: ${theme.colors.main.white};
+  color: ${theme.colors.gray[900]};
+  border-bottom: 1px solid ${theme.colors.gray[300]};
+  text-align: center;
+  line-height: ${theme.typography.lineHeights.lg};
+`;
+
+const headerStyle = css`
+  ${rowStyle};
+  height: 48px;
+  background-color: ${theme.colors.gray[100]};
+  color: ${theme.colors.gray[700]};
+  border-bottom: 1px solid ${theme.colors.gray[500]};
+  font-weight: ${theme.typography.fontWeight.bold};
+`;
+
+const inquirieTitleStyle = css`
+  display: flex;
+  align-items: flex-start;
+  padding: 24px;
+
+  span {
+    color: ${theme.colors.gray[300]};
+    margin-right: 12px;
+  }
+
+  div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+`;
+
+const traderInfoStyle = css`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 8px;
+  padding-left: 24.5px;
+
+  img {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  span {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+`;
+
+const statusStyle = (status: string) => css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 14px;
+  color: ${status === '완료' ? theme.colors.gray[400] : theme.colors.gray[900]};
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    background-color: ${theme.colors.teal[400]};
+    border-radius: 50%;
+    display: ${status === '대기' ? 'block' : 'none'};
+  }
+`;
+
 export default MyInquiriesPage;

--- a/src/pages/mypage/investor/MyInquiriesPage.tsx
+++ b/src/pages/mypage/investor/MyInquiriesPage.tsx
@@ -5,7 +5,18 @@ import Pagination from '@/components/common/Pagination';
 import { ROUTES } from '@/constants/routes';
 import theme from '@/styles/theme';
 
-const myInquirie = [
+type Status = '대기' | '완료';
+
+interface myInquiriesData {
+  id: number;
+  inqurieTitle: string;
+  profileImg: string;
+  nickName: string;
+  inqurieStatus: Status;
+  date: string;
+}
+
+const myInquiries: myInquiriesData[] = [
   {
     id: 1,
     inqurieTitle: '이거 믿을만한 전략인가요?',
@@ -103,7 +114,7 @@ const MyInquiriesPage = () => (
         <div>답변상태</div>
         <div>날짜</div>
       </div>
-      {myInquirie.map((inquirie) => (
+      {myInquiries.map((inquirie) => (
         <Link
           to={`${ROUTES.MYPAGE.INVESTOR.MYINQUIRY.DETAIL(inquirie.id.toString())}`}
           key={inquirie.id}
@@ -114,7 +125,7 @@ const MyInquiriesPage = () => (
               <div>{inquirie.inqurieTitle}</div>
             </div>
             <div css={traderInfoStyle}>
-              <img src={inquirie.profileImg} alt='' />
+              <img src={inquirie.profileImg} alt={`${inquirie.nickName}s profile`} />
               <span>{inquirie.nickName}</span>
             </div>
             <div css={statusStyle(inquirie.inqurieStatus)}>
@@ -126,7 +137,7 @@ const MyInquiriesPage = () => (
         </Link>
       ))}
     </div>
-    <Pagination totalPage={5} limit={10} page={1} setPage={1} />
+    <Pagination totalPage={5} limit={10} page={1} setPage={() => {}} />
   </div>
 );
 
@@ -224,7 +235,7 @@ const traderInfoStyle = css`
   }
 `;
 
-const statusStyle = (status: string) => css`
+const statusStyle = (status: Status) => css`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -23,6 +23,7 @@ import HomePage from '@/pages/HomePage';
 import InvestorFollowFolderPage from '@/pages/mypage/investor/InvestorFollowFolderPage';
 import InvestorMyPage from '@/pages/mypage/investor/InvestorMyPage';
 import InvestorProfilePage from '@/pages/mypage/investor/InvestorProfilePage';
+import MyInquiresDetailPage from '@/pages/mypage/investor/MyInquiresDetailPage';
 import MyInquiriesPage from '@/pages/mypage/investor/MyInquiriesPage';
 import InquiriesManagementPage from '@/pages/mypage/trader/InquiriesManagementPage';
 import StrategyCreatePage from '@/pages/mypage/trader/StrategyCreatePage';
@@ -188,8 +189,12 @@ export const router = createBrowserRouter(
           element: <InvestorFollowFolderPage />, // 특정 폴더의 관심전략 목록
         },
         {
-          path: ROUTES.MYPAGE.INVESTOR.MYINQUIRY,
-          element: <MyInquiriesPage />, // 나의 상담 게시판
+          path: ROUTES.MYPAGE.INVESTOR.MYINQUIRY.LIST,
+          element: <MyInquiriesPage />, // 나의 문의 목록 게시판
+        },
+        {
+          path: ROUTES.MYPAGE.INVESTOR.MYINQUIRY.DETAIL(':inquiryId'),
+          element: <MyInquiresDetailPage />, // 나의 문의 상세 게시판
         },
         {
           path: ROUTES.MYPAGE.INVESTOR.PROFILE,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #127

## 📋 작업 내용

나의 문의(투자자마이페이지) CSS
- 나의 문의 투자자 상세페이지 router 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="1786" alt="image" src="https://github.com/user-attachments/assets/242b136e-06c6-4bc0-bbf0-52517932de8e">

![Nov-19-2024 16-03-56](https://github.com/user-attachments/assets/58d9e541-d201-4f81-99e1-0a5511651418)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

투자자의 마이 페이지에서 '내 문의' 섹션에 대한 CSS 스타일링을 구현하고 개별 문의에 대한 상세 보기를 추가합니다.

새로운 기능:
- 투자자의 마이 페이지 섹션에 개별 문의에 대한 상세 보기를 추가합니다.

개선 사항:
- '내 문의' 섹션에 대한 CSS 스타일링을 구현하여 투자자의 마이 페이지를 개선하고 사용자 인터페이스를 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement CSS styling for the 'My Inquiries' section in the investor's my page and add a detailed view for individual inquiries.

New Features:
- Add a detailed view for individual inquiries in the investor's my page section.

Enhancements:
- Enhance the investor's my page by implementing CSS styling for the 'My Inquiries' section, improving the user interface.

</details>