### PR TITLE
[Refactor] api/auth.ts에서 리액트쿼리 분리 (#155)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,40 +1,14 @@
 // auth.ts
-import { useMutation } from '@tanstack/react-query';
-
 import { apiClient } from '@/api/apiClient';
 import { API_ENDPOINTS } from '@/api/apiEndpoints';
-import { useAuthStore } from '@/stores/authStore';
 import { SigninRequest, SigninResponse } from '@/types/auth';
 
-export const useSignin = () => {
-  const { setAuth } = useAuthStore();
-
-  return useMutation({
-    mutationKey: ['signin'],
-    mutationFn: async (credentials: SigninRequest) => {
-      try {
-        console.log('로그인 시도:', credentials);
-        const { data } = await apiClient.post<SigninResponse>(
-          API_ENDPOINTS.AUTH.LOGIN,
-          credentials
-        ); // 상대경로로 변경
-        console.log('로그인 응답:', data);
-        // 로그인 성공 시
-        if (data.status === 'success' && data.data) {
-          // JWT 토큰과 함께 role 정보를 useAuthStore에 저장
-          setAuth(data.data.token, data.data.user);
-        }
-        return data;
-      } catch (error) {
-        console.error('API 에러:', error);
-        throw error;
-      }
-    },
-    onSuccess: (data) => {
-      console.log('mutation 성공:', data);
-    },
-    onError: (error) => {
-      console.error('mutation 에러:', error);
-    },
-  });
+export const signin = async (credentials: SigninRequest): Promise<SigninResponse> => {
+  try {
+    const { data } = await apiClient.post<SigninResponse>(API_ENDPOINTS.AUTH.LOGIN, credentials);
+    return data;
+  } catch (error) {
+    console.error('Signin API failed:', error);
+    throw error;
+  }
 };

--- a/src/hooks/mutations/useAuthMutation.ts
+++ b/src/hooks/mutations/useAuthMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { signin } from '@/api/auth';
+import { useAuthStore } from '@/stores/authStore';
+import { SigninRequest, SigninResponse } from '@/types/auth';
+
+export const useSigninMutation = () => {
+  const { setAuth } = useAuthStore();
+
+  return useMutation<SigninResponse, Error, SigninRequest>({
+    mutationKey: ['signin'],
+    mutationFn: async (credentials: SigninRequest) => {
+      const response = await signin(credentials);
+      if (response.status === 'success' && response.data) {
+        setAuth(response.data.token, response.data.user);
+      }
+      return response;
+    },
+    onError: (error) => {
+      console.error('Signin mutation error:', error);
+    },
+  });
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -24,15 +24,8 @@ const HomePage = () => {
   const [traderCount, setTraderCount] = useState('0'); // 기본값 설정
   const [strategyCount, setStrategyCount] = useState('0'); // 기본값 설정
 
-  useEffect(() => {
-    // 비로그인 사용자 리다이렉트
-    if (!user) {
-      navigate('/signin', { replace: true });
-      return;
-    }
-    // role 확인용 로깅
-    console.log('Current user role:', user.role);
-  }, [user, navigate]);
+  // role 확인용 로깅
+  console.log('Current user role:', user?.role);
 
   useEffect(() => {
     const fetchTraderStats = async () => {

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -3,10 +3,10 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { useSignin } from '@/api/auth';
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import { ROUTES } from '@/constants/routes';
+import { useSigninMutation } from '@/hooks/mutations/useAuthMutation';
 import theme from '@/styles/theme';
 import { isValidPassword, validateEmail } from '@/utils/validation';
 
@@ -16,7 +16,8 @@ const SignInPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [errorField, setErrorField] = useState<'email' | 'password' | null>(null);
-  const signin = useSignin();
+
+  const { mutateAsync: signin } = useSigninMutation();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -37,7 +38,7 @@ const SignInPage: React.FC = () => {
     }
     try {
       // 콘솔에서 확인
-      const result = await signin.mutateAsync({ email, password });
+      const result = await signin({ email, password });
       if (result.status === 'success' && result.data) {
         // 로그인 성공 시
         // role을 state로 전달하지 않고, 단순 홈으로 이동
@@ -46,6 +47,8 @@ const SignInPage: React.FC = () => {
       }
     } catch (error) {
       console.error('Signin failed: ', error);
+      setErrorMessage('로그인에 실패했습니다. 다시 시도해주세요.');
+      setErrorField(null);
     }
   };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- api/auth.ts 리팩토링(react-query 분리)
- useAuthMutation.ts 추가(/hooks/mutations)
- SignInPage.tsx 수정(/pages/auth)
- 비로그인 사용자 리다이랙트 삭제

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

개선 사항:
- `auth.ts` 파일을 리팩토링하여 react-query 로직을 새로운 커스텀 훅으로 분리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor the auth.ts file to separate react-query logic into a new custom hook.

</details>