### PR TITLE
[Feat] 관리자 매매유형 관리 페이지 API 적용

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -3,24 +3,28 @@ import axios from 'axios';
 import { useAuthStore } from '@/stores/authStore';
 
 export const apiClient = axios.create();
-// MSW와 실제 API를 구분하기 위한 baseURL 설정
+
+// TODO: MSW와 실제 API를 구분하기 위한 baseURL 설정(api 다 나오면 이걸로 변경..)
 // export const API_BASE_URL =
 //   import.meta.env.VITE_ENABLE_MSW === 'true'
 //     ? '' // MSW 사용 시 빈 문자열
 //     : import.meta.env.VITE_BASE_URL;
 
+// export const apiClient = axios.create({
+//   baseURL: API_BASE_URL,
+// });
+
 // TODO: 요청 인터셉터 구현
 // - 요청 URL과 메서드 로깅 (디버깅용)
 // - 엔드포인트 요청 시 헤더에 useMock:true추가 --> msw 데이터 , 추가 안하면 리얼 api
 // - Authorization 헤더에 로그인 토큰 추가 (localStorage or sessionStorage에서 가져오기)
+
 apiClient.interceptors.request.use((config) => {
   if (config.headers.useMock) {
     config.baseURL = '';
     delete config.headers.useMock;
-    console.log('mockup url: ', config.baseURL);
   } else {
     config.baseURL = import.meta.env.VITE_BASE_URL;
-    console.log('realAPI url: ', config.baseURL);
   }
   const { token } = useAuthStore.getState();
   if (token) {

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -2,20 +2,26 @@ import axios from 'axios';
 
 import { useAuthStore } from '@/stores/authStore';
 
+export const apiClient = axios.create();
 // MSW와 실제 API를 구분하기 위한 baseURL 설정
-export const API_BASE_URL =
-  import.meta.env.VITE_ENABLE_MSW === 'true'
-    ? '' // MSW 사용 시 빈 문자열
-    : import.meta.env.VITE_BASE_URL;
-
-export const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-});
+// export const API_BASE_URL =
+//   import.meta.env.VITE_ENABLE_MSW === 'true'
+//     ? '' // MSW 사용 시 빈 문자열
+//     : import.meta.env.VITE_BASE_URL;
 
 // TODO: 요청 인터셉터 구현
 // - 요청 URL과 메서드 로깅 (디버깅용)
+// - 엔드포인트 요청 시 헤더에 useMock:true추가 --> msw 데이터 , 추가 안하면 리얼 api
 // - Authorization 헤더에 로그인 토큰 추가 (localStorage or sessionStorage에서 가져오기)
 apiClient.interceptors.request.use((config) => {
+  if (config.headers.useMock) {
+    config.baseURL = '';
+    delete config.headers.useMock;
+    console.log('mockup url: ', config.baseURL);
+  } else {
+    config.baseURL = import.meta.env.VITE_BASE_URL;
+    console.log('realAPI url: ', config.baseURL);
+  }
   const { token } = useAuthStore.getState();
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
@@ -26,5 +32,12 @@ apiClient.interceptors.request.use((config) => {
 // TODO: 응답 인터셉터 구현
 // - 응답 데이터를 호출부에서 쉽게 처리할 수 있도록 변환
 // - 상태 코드 기반 에러 처리 추가 (401 Unauthorized, 404 Not Found 등)
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error('[Response Error]', error.response || error.message);
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;

--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -1,3 +1,6 @@
 export const API_ENDPOINTS = {
   NOTICES: '/api/notices',
+  ADMIN: {
+    TRADING_TYPES: '/api/admin/trading-types',
+  },
 };

--- a/src/api/stockType.ts
+++ b/src/api/stockType.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+
+import { InvestmentAssetProps } from '@/types/admin';
+
+//투자자산유형 목록 조회
+export const fetchInvestmentTypes = async () => {
+  try {
+    const res = await axios.get(`${import.meta.env.VITE_BASE_URL}/api/admin/inv-asset-classes`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Auth: 'admin',
+      },
+    });
+    return res.data;
+  } catch (error) {
+    console.error('failed to fetch InvestmentTypes', error);
+  }
+};
+
+//투자자산유형 삭제
+export const fetchDeleteInvestmentType = async (id: number) => {
+  try {
+    const req = await axios.delete(
+      `${import.meta.env.VITE_BASE_URL}/api/admin/api/admin/inv-asset-classes/${id}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Auth: 'admin',
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to delete InvestmentType', error);
+  }
+};
+
+//투자자산유형 등록
+export const fetchPostInvestmentType = async ({
+  investmentAssetClassesName,
+  investmentAssetClassesIcon,
+  isActive,
+  currentDataLength,
+}: InvestmentAssetProps & { currentDataLength: number }) => {
+  const body = {
+    order: currentDataLength + 1,
+    investmentAssetClassesName,
+    investmentAssetClassesIcon,
+    isActive,
+  };
+  try {
+    const req = await axios.post(
+      `${import.meta.env.VITE_BASE_URL}/api/admin/inv-asset-classes`,
+      body,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Auth: 'admin',
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to post Investmenttype', error);
+  }
+};

--- a/src/api/tradingType.ts
+++ b/src/api/tradingType.ts
@@ -1,11 +1,16 @@
-import axios from 'axios';
+import { apiClient } from './apiClient';
+import { API_ENDPOINTS } from './apiEndpoints';
 
-import { TradingType } from '@/types/admin';
+import { TradingTypeProps } from '@/types/admin';
 
 //매매유형 목록 조회
-export const fetchTradingTypes = async () => {
+export const fetchTradingTypes = async (page: number, pageSize: number) => {
   try {
-    const res = await axios.get(`${import.meta.env.VITE_BASE_URL}/api/admin/trading-types`, {
+    const res = await apiClient.get(API_ENDPOINTS.ADMIN.TRADING_TYPES, {
+      params: {
+        page,
+        pageSize,
+      },
       headers: {
         'Content-Type': 'application/json',
         Auth: 'admin',
@@ -20,15 +25,12 @@ export const fetchTradingTypes = async () => {
 //매매유형 삭제
 export const fetchDeleteTradingType = async (id: number) => {
   try {
-    const req = await axios.delete(
-      `${import.meta.env.VITE_BASE_URL}/api/admin/trading-types/${id}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Auth: 'admin',
-        },
-      }
-    );
+    const req = await apiClient.delete(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Auth: 'admin',
+      },
+    });
     return req.data;
   } catch (error) {
     console.error('failed to delete tradingType', error);
@@ -40,16 +42,41 @@ export const fetchPostTradingType = async ({
   tradingTypeName,
   tradingTypeIcon,
   isActive,
-  currentDataLength,
-}: TradingType & { currentDataLength: number }) => {
+}: TradingTypeProps) => {
   const body = {
-    order: currentDataLength + 1,
     tradingTypeName,
     tradingTypeIcon,
     isActive,
   };
   try {
-    const req = await axios.post(`${import.meta.env.VITE_BASE_URL}/api/admin/trading-types`, body, {
+    const req = await apiClient.post(API_ENDPOINTS.ADMIN.TRADING_TYPES, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Auth: 'admin',
+      },
+    });
+    return req.data;
+  } catch (error) {
+    console.error('failed to post tradingtype', error);
+  }
+};
+
+//매매유형 수정
+export const fetchPutTradingType = async ({
+  tradingTypeId,
+  tradingTypeOrder,
+  tradingTypeName,
+  tradingTypeIcon,
+  isActive,
+}: TradingTypeProps) => {
+  const body = {
+    tradingTypeOrder,
+    tradingTypeName,
+    tradingTypeIcon,
+    isActive,
+  };
+  try {
+    const req = await apiClient.put(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${tradingTypeId}`, body, {
       headers: {
         'Content-Type': 'application/json',
         Auth: 'admin',

--- a/src/api/tradingType.ts
+++ b/src/api/tradingType.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+
+import { TradingType } from '@/types/admin';
+
+//매매유형 목록 조회
+export const fetchTradingTypes = async () => {
+  try {
+    const res = await axios.get(`${import.meta.env.VITE_BASE_URL}/api/admin/trading-types`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Auth: 'admin',
+      },
+    });
+    return res.data;
+  } catch (error) {
+    console.error('failed to fetch tradingTypes', error);
+  }
+};
+
+//매매유형 삭제
+export const fetchDeleteTradingType = async (id: number) => {
+  try {
+    const req = await axios.delete(
+      `${import.meta.env.VITE_BASE_URL}/api/admin/trading-types/${id}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Auth: 'admin',
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to delete tradingType', error);
+  }
+};
+
+//매매유형 등록
+export const fetchPostTradingType = async ({
+  tradingTypeName,
+  tradingTypeIcon,
+  isActive,
+  currentDataLength,
+}: TradingType & { currentDataLength: number }) => {
+  const body = {
+    order: currentDataLength + 1,
+    tradingTypeName,
+    tradingTypeIcon,
+    isActive,
+  };
+  try {
+    const req = await axios.post(`${import.meta.env.VITE_BASE_URL}/api/admin/trading-types`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Auth: 'admin',
+      },
+    });
+    return req.data;
+  } catch (error) {
+    console.error('failed to post tradingtype', error);
+  }
+};

--- a/src/api/tradingType.ts
+++ b/src/api/tradingType.ts
@@ -23,18 +23,16 @@ export const fetchTradingTypes = async (page: number, pageSize: number) => {
 };
 
 //매매유형 삭제
-export const fetchDeleteTradingType = async (id: number) => {
-  try {
-    const req = await apiClient.delete(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${id}`, {
-      headers: {
-        'Content-Type': 'application/json',
-        Auth: 'admin',
-      },
-    });
-    return req.data;
-  } catch (error) {
-    console.error('failed to delete tradingType', error);
-  }
+export const fetchDeleteTradingType = async (
+  id: number
+): Promise<{ msg: string; timestamp: string }> => {
+  const req = await apiClient.delete(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${id}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Auth: 'admin',
+    },
+  });
+  return req.data;
 };
 
 //매매유형 등록
@@ -42,23 +40,20 @@ export const fetchPostTradingType = async ({
   tradingTypeName,
   tradingTypeIcon,
   isActive,
-}: TradingTypeProps) => {
+}: TradingTypeProps): Promise<{ msg: string; timestamp: string }> => {
   const body = {
     tradingTypeName,
     tradingTypeIcon,
     isActive,
   };
-  try {
-    const req = await apiClient.post(API_ENDPOINTS.ADMIN.TRADING_TYPES, body, {
-      headers: {
-        'Content-Type': 'application/json',
-        Auth: 'admin',
-      },
-    });
-    return req.data;
-  } catch (error) {
-    console.error('failed to post tradingtype', error);
-  }
+
+  const req = await apiClient.post(API_ENDPOINTS.ADMIN.TRADING_TYPES, body, {
+    headers: {
+      'Content-Type': 'application/json',
+      Auth: 'admin',
+    },
+  });
+  return req.data;
 };
 
 //매매유형 수정
@@ -68,22 +63,19 @@ export const fetchPutTradingType = async ({
   tradingTypeName,
   tradingTypeIcon,
   isActive,
-}: TradingTypeProps) => {
+}: TradingTypeProps): Promise<{ msg: string; timestamp: string }> => {
   const body = {
     tradingTypeOrder,
     tradingTypeName,
     tradingTypeIcon,
     isActive,
   };
-  try {
-    const req = await apiClient.put(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${tradingTypeId}`, body, {
-      headers: {
-        'Content-Type': 'application/json',
-        Auth: 'admin',
-      },
-    });
-    return req.data;
-  } catch (error) {
-    console.error('failed to post tradingtype', error);
-  }
+
+  const req = await apiClient.put(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${tradingTypeId}`, body, {
+    headers: {
+      'Content-Type': 'application/json',
+      Auth: 'admin',
+    },
+  });
+  return req.data;
 };

--- a/src/components/page/admin/FileInput.tsx
+++ b/src/components/page/admin/FileInput.tsx
@@ -3,29 +3,36 @@ import { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
-import Input from '@/components/common/Input';
 import theme from '@/styles/theme';
 
 interface FileInputProps {
   title: string;
   file?: File | null;
-  onFileChange: (file: File | null) => void;
+  fname: string;
+  icon: string;
+  onNameChange: (name: string) => void;
 }
-const FileInput = ({ title, file, onFileChange }: FileInputProps) => {
+const FileInput = ({ title, file, fname, icon, onNameChange }: FileInputProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(file || null);
-  const [fileName, setFileName] = useState('');
+  const [fileName, setFileName] = useState(fname);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    //이거 임시임 여기에 올리는 이미지 파일을 s3에 올린 후 그 이미지 url로 가져오는 로직 들어가야함 그 Url이 아이콘임 ~
     if (e.target.files) {
       setSelectedFile(e.target.files[0]);
       setFileName(e.target.files[0].name);
-      onFileChange(e.target.files[0]);
     }
   };
 
   const handleFileUpload = () => {
     if (fileInputRef.current) fileInputRef.current.click();
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    setFileName(newName);
+    onNameChange(newName);
   };
 
   useEffect(() => {
@@ -38,18 +45,20 @@ const FileInput = ({ title, file, onFileChange }: FileInputProps) => {
   return (
     <div css={inputStyle}>
       <div css={titleStyle}>{title}</div>
-      <Input
+      <input
+        type='text'
         css={showTitleStyle}
         placeholder='유형 이름을 입력하세요'
         value={fileName}
-        onChange={(e) => setFileName(e.target.value)}
+        onChange={handleNameChange}
       />
       <div css={titleStyle}>아이콘</div>
       {selectedFile && (
         <img src={URL.createObjectURL(selectedFile)} alt={selectedFile.name} css={imageStyle} />
       )}
+      {icon && !selectedFile && <img src={icon} alt={icon} css={imageStyle} />}
       <div css={inputAndButtonContainerStyle}>
-        <input type='text' value={fileName || ''} readOnly css={inputStyleOverride} />
+        <input type='text' value={icon || ''} readOnly css={inputStyleOverride} />
         <Button variant='secondary' size='sm' onClick={handleFileUpload} width={115}>
           찾아보기
         </Button>
@@ -80,7 +89,6 @@ const titleStyle = css`
 
 const imageStyle = css`
   align-self: flex-start;
-
   height: 40px;
   margin: 10px 0;
 `;
@@ -107,6 +115,14 @@ const inputStyleOverride = css`
 
 const showTitleStyle = css`
   margin: 12px 0 10px 0;
+  padding: 5px;
+  border: 1px solid ${theme.colors.gray[300]};
+  background-color: ${theme.colors.main.white};
+  outline: none;
+  transition: all 0.2s ease;
+  height: ${theme.input.height.md};
+  padding: ${theme.input.padding.md};
+  font-size: ${theme.input.fontSize.md};
 `;
 
 const fileInputStyle = css`

--- a/src/components/page/admin/FileInput.tsx
+++ b/src/components/page/admin/FileInput.tsx
@@ -16,6 +16,7 @@ const FileInput = ({ title, file, fname, icon, onNameChange }: FileInputProps) =
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(file || null);
   const [fileName, setFileName] = useState(fname);
+  const [message, setMessage] = useState('');
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     //이거 임시임 여기에 올리는 이미지 파일을 s3에 올린 후 그 이미지 url로 가져오는 로직 들어가야함 그 Url이 아이콘임 ~
@@ -31,6 +32,9 @@ const FileInput = ({ title, file, fname, icon, onNameChange }: FileInputProps) =
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
+    if (newName.length > 10) {
+      return;
+    }
     setFileName(newName);
     onNameChange(newName);
   };

--- a/src/components/page/admin/FileInput.tsx
+++ b/src/components/page/admin/FileInput.tsx
@@ -16,7 +16,6 @@ const FileInput = ({ title, file, fname, icon, onNameChange }: FileInputProps) =
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(file || null);
   const [fileName, setFileName] = useState(fname);
-  const [message, setMessage] = useState('');
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     //이거 임시임 여기에 올리는 이미지 파일을 s3에 올린 후 그 이미지 url로 가져오는 로직 들어가야함 그 Url이 아이콘임 ~

--- a/src/components/page/admin/TypeTable.tsx
+++ b/src/components/page/admin/TypeTable.tsx
@@ -20,9 +20,10 @@ interface DataProps {
   attributes: AttributeProps[];
   data: TypeTableProps[];
   onSelectChange: (selectedIdx: number[]) => void;
+  onEdit: (id: number) => void;
 }
 
-const TypeTable = ({ attributes, data, onSelectChange }: DataProps) => {
+const TypeTable = ({ attributes, data, onSelectChange, onEdit }: DataProps) => {
   const [selected, setSelected] = useState<boolean[]>(new Array(data.length).fill(false));
   const [selectAll, setSelectAll] = useState(false);
 
@@ -39,9 +40,7 @@ const TypeTable = ({ attributes, data, onSelectChange }: DataProps) => {
     updatedSelected[idx] = !updatedSelected[idx];
     setSelected(updatedSelected);
 
-    const selectedIds = data.filter((_, index) => updatedSelected[index]).map((item) => item.id);
-
-    setSelectAll(updatedSelected.every(Boolean));
+    const selectedIds = data.filter((d) => updatedSelected[d.id]).map((item) => item.id);
     onSelectChange(selectedIds);
   };
 
@@ -64,16 +63,19 @@ const TypeTable = ({ attributes, data, onSelectChange }: DataProps) => {
           {data.map((row, idx) => (
             <tr key={idx} css={tableRowStyle}>
               <td css={tableCellStyle}>
-                <Checkbox checked={selected[idx]} onChange={() => handleSelect(idx)} />
+                <Checkbox
+                  checked={selected[row.id] ?? false}
+                  onChange={() => handleSelect(row.id)}
+                />
               </td>
               <td css={tableCellStyle} colSpan={4}>
-                <img src={row.icon} alt={row.title} css={tableImgStyle} />
+                <img src={row.icon} alt={row.icon} css={tableImgStyle} />
               </td>
               <td css={tableCellStyle} colSpan={2}>
                 {row.title}
               </td>
               <td css={tableCellStyle} colSpan={2}>
-                <Button variant='accent' size='xs' width={72}>
+                <Button variant='accent' size='xs' width={72} onClick={() => onEdit(row.id)}>
                   수정
                 </Button>
               </td>

--- a/src/components/page/admin/TypeTable.tsx
+++ b/src/components/page/admin/TypeTable.tsx
@@ -19,29 +19,31 @@ interface AttributeProps {
 interface DataProps {
   attributes: AttributeProps[];
   data: TypeTableProps[];
+  selectedItems: number[];
   onSelectChange: (selectedIdx: number[]) => void;
   onEdit: (id: number) => void;
 }
 
-const TypeTable = ({ attributes, data, onSelectChange, onEdit }: DataProps) => {
-  const [selected, setSelected] = useState<boolean[]>(new Array(data.length).fill(false));
+const TypeTable = ({ attributes, data, selectedItems, onSelectChange, onEdit }: DataProps) => {
   const [selectAll, setSelectAll] = useState(false);
 
   const handleAllChecked = () => {
     const newSelectAll = !selectAll;
     setSelectAll(newSelectAll);
-    setSelected(new Array(data.length).fill(newSelectAll));
-    const selectIdx = newSelectAll ? data.map((item) => item.id) : [];
-    onSelectChange(selectIdx);
+    if (newSelectAll) {
+      const selectIdx = data.map((item) => item.id);
+      onSelectChange(selectIdx);
+    } else {
+      onSelectChange([]);
+    }
   };
 
   const handleSelect = (idx: number) => {
-    const updatedSelected = [...selected];
-    updatedSelected[idx] = !updatedSelected[idx];
-    setSelected(updatedSelected);
+    const updatedSelected = selectedItems.includes(idx)
+      ? selectedItems.filter((item) => item !== idx)
+      : [...selectedItems, idx];
 
-    const selectedIds = data.filter((d) => updatedSelected[d.id]).map((item) => item.id);
-    onSelectChange(selectedIds);
+    onSelectChange(updatedSelected);
   };
 
   return (
@@ -53,7 +55,7 @@ const TypeTable = ({ attributes, data, onSelectChange, onEdit }: DataProps) => {
               <Checkbox checked={selectAll} onChange={handleAllChecked} />
             </th>
             {attributes.map((row, idx) => (
-              <th key={idx} css={tableHeadStyle} colSpan={idx === 0 ? 4 : 2}>
+              <th key={idx} css={tableHeadStyle} colSpan={idx === 0 ? 4 : idx === 1 ? 3 : 2}>
                 {row.item}
               </th>
             ))}
@@ -64,14 +66,14 @@ const TypeTable = ({ attributes, data, onSelectChange, onEdit }: DataProps) => {
             <tr key={idx} css={tableRowStyle}>
               <td css={tableCellStyle}>
                 <Checkbox
-                  checked={selected[row.id] ?? false}
+                  checked={selectedItems.includes(row.id) ?? false}
                   onChange={() => handleSelect(row.id)}
                 />
               </td>
               <td css={tableCellStyle} colSpan={4}>
                 <img src={row.icon} alt={row.icon} css={tableImgStyle} />
               </td>
-              <td css={tableCellStyle} colSpan={2}>
+              <td css={tableCellStyle} colSpan={3}>
                 {row.title}
               </td>
               <td css={tableCellStyle} colSpan={2}>
@@ -86,6 +88,17 @@ const TypeTable = ({ attributes, data, onSelectChange, onEdit }: DataProps) => {
     </div>
   );
 };
+
+const tableStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  width: 100%;
+  .checkbox {
+    cursor: pointer;
+  }
+`;
 
 const tableVars = css`
   width: 100%;
@@ -123,17 +136,6 @@ const tableImgStyle = css`
   margin: 0 auto;
   height: 20px;
   object-fit: cover;
-`;
-
-const tableStyle = css`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 16px;
-  width: 100%;
-  .checkbox {
-    cursor: pointer;
-  }
 `;
 
 export default TypeTable;

--- a/src/hooks/useTradingType.ts
+++ b/src/hooks/useTradingType.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
 
 import {
   fetchPostTradingType,

--- a/src/hooks/useTradingType.ts
+++ b/src/hooks/useTradingType.ts
@@ -1,0 +1,41 @@
+import { keepPreviousData, useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+
+import {
+  fetchPostTradingType,
+  fetchPutTradingType,
+  fetchDeleteTradingType,
+} from '@/api/tradingType';
+import { TradingTypeProps } from '@/types/admin';
+
+export const useAddTradingType = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ msg: string; timestamp: string }, Error, TradingTypeProps>({
+    mutationFn: (data: TradingTypeProps) => fetchPostTradingType(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tradingTypes'] });
+    },
+  });
+};
+
+export const usePutTradingType = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ msg: string; timestamp: string }, Error, TradingTypeProps>({
+    mutationFn: (data: TradingTypeProps) => fetchPutTradingType(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tradingTypes'] });
+    },
+  });
+};
+
+export const useDeleteTradingType = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ msg: string; timestamp: string }, Error, number>({
+    mutationFn: (data: number) => fetchDeleteTradingType(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tradingTypes'] });
+    },
+  });
+};

--- a/src/pages/admin/stock-type/StockTypeListPage.tsx
+++ b/src/pages/admin/stock-type/StockTypeListPage.tsx
@@ -94,19 +94,12 @@ const StockTypeListPage = () => {
     }
   };
 
-  const handleUploadIcon = (file: File | null) => {
-    if (file) {
-      const fileURL = URL.createObjectURL(file);
-      setMockStocks((prevItems) =>
-        prevItems.map((item) => (item.id === selectedStocks[0] ? { ...item, icon: fileURL } : item))
-      );
-    }
-  };
-
   const handleUpload = () => {
     openContentModal({
       title: '상품유형 등록',
-      content: <FileInput title='상품유형' onFileChange={handleUploadIcon} />,
+      content: (
+        <FileInput title='상품유형' file={null} fname={''} icon={''} onNameChange={() => {}} />
+      ),
       onAction: () => {
         console.log('상품유형 등록 api');
       },
@@ -130,6 +123,7 @@ const StockTypeListPage = () => {
         attributes={stockAttributes}
         data={mockStocks}
         onSelectChange={handleSelectChange}
+        onEdit={() => {}}
       />
       <Modal />
       <ContentModal />

--- a/src/pages/admin/stock-type/StockTypeListPage.tsx
+++ b/src/pages/admin/stock-type/StockTypeListPage.tsx
@@ -122,6 +122,7 @@ const StockTypeListPage = () => {
       <TypeTable
         attributes={stockAttributes}
         data={mockStocks}
+        selectedItems={selectedStocks}
         onSelectChange={handleSelectChange}
         onEdit={() => {}}
       />

--- a/src/pages/test-page/APITestPage.tsx
+++ b/src/pages/test-page/APITestPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import axios from 'axios';
 
-import { API_BASE_URL, apiClient } from '@/api/apiClient';
+import { apiClient } from '@/api/apiClient';
 import { API_ENDPOINTS } from '@/api/apiEndpoints';
 
 interface Notice {
@@ -82,15 +82,25 @@ const APITestPage = () => {
   useEffect(() => {
     const fetchNotices = async () => {
       try {
-        console.log('API_BASE_URL:', API_BASE_URL);
         console.log('apiClient baseURL:', apiClient.defaults.baseURL);
 
-        const response = await apiClient.get(API_ENDPOINTS.NOTICES);
+        const response = await apiClient.get('/mock/api/example', {
+          headers: {
+            useMock: true,
+          },
+        });
         const data = await response.data;
         setNotices(data);
 
+        const response1 = await apiClient.get(API_ENDPOINTS.ADMIN.TRADING_TYPES, {
+          headers: {
+            Authorization: 'admin',
+          },
+        });
+        console.log('API Response: ', response1.data);
+
         console.log('Response status:', response.status);
-        console.log('API Response:', data);
+        console.log('mockAPI Response:', data);
       } catch (error) {
         if (axios.isAxiosError(error)) {
           setError(error.response?.data?.message || 'An error occurred while fetching notices');

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,12 @@
+export interface TradingType {
+  tradingTypeOrder?: number;
+  tradingTypeName: string;
+  tradingTypeIcon: string;
+  isActive?: string;
+}
+
+export interface InvestmentAssetClass {
+  investmentAssetClassesId: number;
+  investmentAssetClassesName: string;
+  investmentAssetClassesIcon: string;
+}

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,12 +1,14 @@
-export interface TradingType {
+export interface TradingTypeProps {
+  tradingTypeId?: number;
   tradingTypeOrder?: number;
   tradingTypeName: string;
   tradingTypeIcon: string;
   isActive?: string;
 }
 
-export interface InvestmentAssetClass {
-  investmentAssetClassesId: number;
+export interface InvestmentAssetProps {
+  order: number;
   investmentAssetClassesName: string;
   investmentAssetClassesIcon: string;
+  isActive: string;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

관리자 매매유형 페이지 CRUD api 적용
아직 이미지 아이콘 업로드 부분은 구현되지 않은 상태입니다. 구현되는대로 반영해서 올리도록 하겠습니다.
지금은 이미지 파일을 업로드 해도 이미지는 올라가지 않습니다
아이콘 업로드 반영 시 예외처리도 함께 해서 올리도록 하겠습니닷
stockType은 아직 상품유형관리쪽은 적용이 안되어있습니다 이 부분 crud 작업하면서 stockType도 apiClient로 바꿀 예정입니다.


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

apiClient

- msw를 사용하는 경우 엔드포인트 헤더에 useMock:true 적어주시면 됩니다..

## 📸 스크린샷 (선택 사항)
![스크린샷 2024-11-20 오전 12 22 10](https://github.com/user-attachments/assets/86efceb9-7bac-44b4-b5c6-25dc40c934da)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

관리자 거래 유형 관리 페이지에 대한 CRUD API를 통합하여 모의 데이터를 실제 데이터로 대체하고 페이지 매김 지원을 추가합니다.

새로운 기능:
- 관리자 거래 유형 관리 페이지에 대한 CRUD API 통합 구현.

개선 사항:
- TradingTypeListPage를 모의 데이터 대신 API의 실제 데이터를 사용하도록 리팩터링.
- react-query를 사용하여 거래 유형 목록에 페이지 매김 지원 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate CRUD API for the admin trading type management page, replacing mock data with real data and adding pagination support.

New Features:
- Implement CRUD API integration for the admin trading type management page.

Enhancements:
- Refactor the TradingTypeListPage to use real data from the API instead of mock data.
- Add pagination support to the trading type list using react-query.

</details>