### PR TITLE
[Feat] 닉네임 중복검사 기능 구현 (msw)

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -6,6 +6,7 @@ export const API_ENDPOINTS = {
   AUTH: {
     LOGIN: '/api/members/login',
     SIGNUP: '/api/members/signup',
+    CHECK_NICKNAME: '/api/members/check-nickname', // 닉네임 중복 확인
   },
   STRATEGY: {
     CREATE: '/api/strategies', // 전략 등록

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -12,3 +12,11 @@ export const signin = async (credentials: SigninRequest): Promise<SigninResponse
     throw error;
   }
 };
+
+export const checkNicknameDuplicate = async (nickname: string) => {
+  const { data } = await apiClient.get(
+    `${API_ENDPOINTS.AUTH.CHECK_NICKNAME}?nickname=${encodeURIComponent(nickname)}`,
+    { headers: { useMock: import.meta.env.VITE_ENABLE_MSW === 'true' } }
+  );
+  return data;
+};

--- a/src/components/page/signup/SignUpForm.tsx
+++ b/src/components/page/signup/SignUpForm.tsx
@@ -1,68 +1,137 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
+import { useNicknameCheck } from '@/hooks/mutations/useNicknameCheck';
 import theme from '@/styles/theme';
+import { validateNickname } from '@/utils/validation';
 
-const SignUpForm = () => (
-  <div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='email' css={labelStyle}>
-        이메일
-      </label>
-      <Input id='email' inputSize='md' placeholder='1234@naver.com' />
-      <Button variant='primary' size='sm' width={100}>
-        인증요청
-      </Button>
+const SignUpForm = () => {
+  const [nickname, setNickname] = useState('');
+  const [nicknameMessage, setNicknameMessage] = useState('');
+  const nicknameCheck = useNicknameCheck();
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    if (!e.target.value) {
+      setNicknameMessage('');
+    }
+  };
+
+  const handleNicknameCheck = async () => {
+    const validation = validateNickname(nickname);
+    if (!validation.isValid) {
+      setNicknameMessage(validation.message);
+      return;
+    }
+
+    try {
+      const response = await nicknameCheck.mutateAsync(nickname);
+      if (response.data.isDuplicate) {
+        setNicknameMessage('이미 사용중인 닉네임입니다.');
+      } else {
+        setNicknameMessage('사용 가능한 닉네임입니다.');
+      }
+    } catch (error) {
+      setNicknameMessage('닉네임 중복 확인에 실패했습니다.');
+    }
+  };
+
+  const handleNicknameBlur = () => {
+    if (nicknameMessage.includes('사용 가능')) {
+      setNicknameMessage('');
+    }
+  };
+  return (
+    <div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='email' css={labelStyle}>
+          이메일
+        </label>
+        <Input id='email' inputSize='md' placeholder='1234@naver.com' />
+        <Button variant='primary' size='sm' width={100}>
+          인증요청
+        </Button>
+      </div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='auth_code' css={labelStyle}>
+          인증번호
+        </label>
+        <Input id='auth_code' inputSize='md' placeholder='인증번호 6자리' />
+        <Button variant='primary' size='sm' width={100}>
+          확인
+        </Button>
+      </div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='password' css={labelStyle}>
+          비밀번호
+        </label>
+        <Input
+          id='password'
+          type='password'
+          inputSize='md'
+          placeholder='영문 숫자를 포함한 8자 이상'
+        />
+      </div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='password_check' css={labelStyle}>
+          비밀번호 확인
+        </label>
+        <Input
+          id='password_check'
+          type='password'
+          inputSize='md'
+          placeholder='비밀번호를 한번 더 입력해주세요.'
+        />
+      </div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='nickname' css={labelStyle}>
+          닉네임
+        </label>
+        <div css={divGroupStyle}>
+          <Input
+            id='nickname'
+            inputSize='md'
+            placeholder='사용할 닉네임을 입력해주세요.'
+            showClearButton
+            value={nickname}
+            onChange={handleNicknameChange}
+            onBlur={handleNicknameBlur}
+            status={
+              nicknameMessage
+                ? nicknameMessage.includes('사용 가능')
+                  ? 'success'
+                  : 'error'
+                : 'default'
+            }
+          />
+          {nicknameMessage && (
+            <p css={[messageStyle, nicknameMessage.includes('사용 가능') && successMessageStyle]}>
+              {nicknameMessage}
+            </p>
+          )}
+        </div>
+        <Button
+          variant='primary'
+          size='sm'
+          width={100}
+          onClick={handleNicknameCheck}
+          disabled={!nickname || nicknameCheck.isPending}
+        >
+          중복확인
+        </Button>
+      </div>
+      <div css={inputGroupStyle}>
+        <label htmlFor='phone' css={labelStyle}>
+          휴대폰번호
+        </label>
+        <Input id='phone' inputSize='md' placeholder='01012345678' />
+      </div>
     </div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='auth_code' css={labelStyle}>
-        인증번호
-      </label>
-      <Input id='auth_code' inputSize='md' placeholder='인증번호 6자리' />
-      <Button variant='primary' size='sm' width={100}>
-        확인
-      </Button>
-    </div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='password' css={labelStyle}>
-        비밀번호
-      </label>
-      <Input
-        id='password'
-        type='password'
-        inputSize='md'
-        placeholder='영문 숫자를 포함한 8자 이상'
-      />
-    </div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='password_check' css={labelStyle}>
-        비밀번호 확인
-      </label>
-      <Input
-        id='password_check'
-        type='password'
-        inputSize='md'
-        placeholder='비밀번호를 한번 더 입력해주세요.'
-      />
-    </div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='nickname' css={labelStyle}>
-        닉네임
-      </label>
-      <Input id='nickname' inputSize='md' placeholder='사용할 닉네임을 입력해주세요.' />
-      <Button variant='primary' size='sm' width={100}>
-        중복확인
-      </Button>
-    </div>
-    <div css={inputGroupStyle}>
-      <label htmlFor='phone' css={labelStyle}>
-        휴대폰번호
-      </label>
-      <Input id='phone' inputSize='md' placeholder='01012345678' />
-    </div>
-  </div>
-);
+  );
+};
 
 const inputGroupStyle = css`
   display: flex;
@@ -86,5 +155,25 @@ const labelStyle = css`
   font-weight: ${theme.typography.fontWeight.regular};
   line-height: ${theme.typography.lineHeights.lg};
 `;
-
+const divGroupStyle = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  p {
+    position: absolute;
+    left: 0;
+    text-indent: 5px;
+    bottom: -20px;
+  }
+`;
+const messageStyle = css`
+  margin-top: 16px;
+  text-align: center;
+  color: ${theme.colors.main.alert};
+  font-size: ${theme.typography.fontSizes.caption};
+  line-height: ${theme.typography.lineHeights.sm};
+`;
+const successMessageStyle = css`
+  color: ${theme.colors.main.primary};
+`;
 export default SignUpForm;

--- a/src/components/page/signup/SignUpForm.tsx
+++ b/src/components/page/signup/SignUpForm.tsx
@@ -101,14 +101,19 @@ const SignUpForm = () => {
             onBlur={handleNicknameBlur}
             status={
               nicknameMessage
-                ? nicknameMessage.includes('사용 가능')
+                ? nicknameMessage.includes('사용 가능한 닉네임')
                   ? 'success'
                   : 'error'
                 : 'default'
             }
           />
           {nicknameMessage && (
-            <p css={[messageStyle, nicknameMessage.includes('사용 가능') && successMessageStyle]}>
+            <p
+              css={[
+                messageStyle,
+                nicknameMessage.includes('사용 가능한 닉네임') && successMessageStyle,
+              ]}
+            >
               {nicknameMessage}
             </p>
           )}

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -5,8 +5,12 @@ export const REGEX = {
   code: /^\d{6}$/,
   // 이메일: 기본 이메일 형식
   email: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-  // 닉네임: 영문 대소문자와 숫자만
-  nickname: /^[a-zA-Z0-9]+$/,
+  // 닉네임: 영문 대소문자와 숫자 조합 필수, 2-10자 사이, 공백 불가능 ✅
+  nickname: {
+    onlyAlphanumeric: /^[a-zA-Z0-9]+$/, // 영문자와 숫자만 허용
+    hasNumber: /[0-9]/, // 숫자 포함
+    hasLetter: /[a-zA-Z]/, // 영문자 포함
+  },
   // 비밀번호: 영문, 숫자, 특수문자 포함 8자 이상
   password: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
   // 공백 검사
@@ -25,6 +29,7 @@ export const VALIDATION_MESSAGE = {
     length: '닉네임은 2-10자 사이여야 합니다.',
     whitespace: '공백은 사용할 수 없습니다.',
     charset: '영문 대소문자와 숫자만 사용 가능합니다.',
+    combination: '영문자와 숫자를 반드시 함께 사용해야 합니다.',
     valid: '유효한 닉네임입니다.',
   },
   password: {

--- a/src/hooks/mutations/useNicknameCheck.ts
+++ b/src/hooks/mutations/useNicknameCheck.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { checkNicknameDuplicate } from '@/api/auth';
+
+export const useNicknameCheck = () =>
+  useMutation({
+    mutationFn: checkNicknameDuplicate,
+    onError: (error) => {
+      console.error('Failed to check nickname:', error);
+    },
+  });

--- a/src/mocks/handlers/auth.handlers.ts
+++ b/src/mocks/handlers/auth.handlers.ts
@@ -8,21 +8,21 @@ const MOCK_USER = [
     member_id: 1,
     email: 'investor@example.com',
     password: 'Password1!',
-    nickname: '투자자',
+    nickname: 'investor11',
     role: 'INVESTOR',
   },
   {
     member_id: 2,
     email: 'trader@example.com',
     password: 'Password1!',
-    nickname: '트레이더',
+    nickname: 'trader444',
     role: 'TRADER',
   },
   {
     member_id: 3,
     email: 'admin@example.com',
     password: 'Password1!',
-    nickname: '관리자',
+    nickname: 'adminking',
     role: 'ADMIN',
   },
 ];
@@ -55,6 +55,23 @@ export const signinHandler = [
       data: {
         token: `mock-jwt-token-${user.role.toLowerCase()}`,
         user: userWithoutPassword,
+      },
+    });
+  }),
+];
+
+// 닉네임 중복 확인 핸들러
+export const checkNicknameHandler = [
+  http.get(`${API_ENDPOINTS.AUTH.CHECK_NICKNAME}*`, ({ request }) => {
+    const url = new URL(request.url);
+    const nickname = url.searchParams.get('nickname');
+    console.log('MSW: Check nickname request intercepted', nickname);
+    const isDuplicate = MOCK_USER.some((user) => user.nickname === nickname); // 닉네임 중복 확인
+
+    return HttpResponse.json({
+      status: 'success',
+      data: {
+        isDuplicate,
       },
     });
   }),

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,4 @@
-import { signinHandler } from '@/mocks/handlers/auth.handlers';
+import { checkNicknameHandler, signinHandler } from '@/mocks/handlers/auth.handlers';
 import { exampleHandlers } from '@/mocks/handlers/example.handlers';
 import { strategyHandlers } from '@/mocks/handlers/strategy.handlers';
 import { strategyDetailHandlers } from '@/mocks/handlers/strategyDetail.handlers';
@@ -8,4 +8,5 @@ export const handlers = [
   ...strategyHandlers,
   ...exampleHandlers,
   ...strategyDetailHandlers,
+  ...checkNicknameHandler,
 ];

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -11,6 +11,7 @@ export const validateEmail = (value: string) => ({
   message: value ? VALIDATION_MESSAGE.email.invalid : VALIDATION_MESSAGE.email.empty,
 });
 
+// 닉네임 유효성 검사 함수 수정본
 export const validateNickname = (nickname: string) => {
   if (nickname.length < 2 || nickname.length > 10) {
     return {
@@ -19,6 +20,7 @@ export const validateNickname = (nickname: string) => {
     };
   }
 
+  // 공백검사
   if (REGEX.whitespace.test(nickname)) {
     return {
       isValid: false,
@@ -26,10 +28,20 @@ export const validateNickname = (nickname: string) => {
     };
   }
 
-  if (!REGEX.nickname.test(nickname)) {
+  // 영문자와 숫자로만 구성되었는지 검사할게!
+  if (!REGEX.nickname.onlyAlphanumeric.test(nickname)) {
     return {
       isValid: false,
       message: VALIDATION_MESSAGE.nickname.charset,
+    };
+  }
+  // 숫자와 영문자가 모두 포함되었는지 검사할게!
+  const hasNumber = REGEX.nickname.hasNumber.test(nickname);
+  const hasLetter = REGEX.nickname.hasLetter.test(nickname);
+  if (!hasNumber || !hasLetter) {
+    return {
+      isValid: false,
+      message: VALIDATION_MESSAGE.nickname.combination,
     };
   }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 입력창에 닉네임을 입력하면 중복검사 버튼이 활성화
- 중복검사 버튼을 클릭하면, 유효성 검사 및 서버에 닉네임 중복검사 요청을 보냄
- 서버에서 닉네임 중복검사 결과를 받아, 중복인 경우 에러 메시지를 출력
- 에러/ 성공메시지 출력 시 상태에 다라 스타일 적용

텍스트상수 등 추후 리팩토링 예정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/40b35ece-fa28-4a5e-a5d9-56e0f6e05b42



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

회원가입 양식에 별명 중복 확인 기능을 구현하여 사용자가 별명 사용 가능 여부를 확인할 수 있도록 합니다. 중복 확인 프로세스를 관리하기 위한 새로운 훅을 도입하고 이 기능을 지원하기 위해 모의 핸들러를 업데이트합니다.

새로운 기능:
- 회원가입 양식에 별명 중복 확인 기능을 구현하여 사용자가 진행하기 전에 별명이 이미 사용 중인지 확인할 수 있도록 합니다.

개선 사항:
- react-query를 사용하여 별명 중복 확인을 처리하기 위한 새로운 훅, useNicknameCheck를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement nickname duplication check functionality in the signup form, enabling users to verify nickname availability. Introduce a new hook to manage the duplication check process and update mock handlers to support this feature.

New Features:
- Implement nickname duplication check feature in the signup form, allowing users to verify if a nickname is already in use before proceeding.

Enhancements:
- Add a new hook, useNicknameCheck, to handle nickname duplication checks using react-query.

</details>