### PR TITLE
[feat] 트레이더 목록 페이지 추가수정 건

### DIFF
--- a/src/components/common/TraderList.tsx
+++ b/src/components/common/TraderList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { MdArrowForward } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import theme from '@/styles/theme';
 
@@ -10,8 +10,7 @@ interface TraderData {
   profileImage: string;
   description: string;
   strategiesCount: number;
-  // followersCount: number;
-  // createdAt: string;
+  createdAt: string; // 필요한지 확인 필요
 }
 
 interface TraderListProps {
@@ -20,8 +19,6 @@ interface TraderListProps {
 }
 
 const TraderList = ({ traders, badgeRank }: TraderListProps) => {
-  const navigate = useNavigate();
-
   if (traders.length === 0) {
     return (
       <div css={emptyContainerStyle}>
@@ -33,7 +30,11 @@ const TraderList = ({ traders, badgeRank }: TraderListProps) => {
   return (
     <div css={containerStyle}>
       {traders.map((trader) => (
-        <div css={cardStyle} key={trader.traderId}>
+        <Link
+          to={`/traders/${trader.traderId}`} // 네비게이션 경로 지정
+          css={cardStyle} // 카드 스타일 적용
+          key={trader.traderId}
+        >
           {/* 좌측: 프로필 이미지 및 뱃지 */}
           <div css={badgeContainerStyle}>
             <img src={trader.profileImage} alt={`${trader.name} 프로필`} css={profileImageStyle} />
@@ -52,14 +53,10 @@ const TraderList = ({ traders, badgeRank }: TraderListProps) => {
                 <span css={separatorStyle}></span>
                 <span css={strategyNumberStyle}>{trader.strategiesCount.toLocaleString()}개</span>
               </span>
-              <MdArrowForward
-                size={24}
-                onClick={() => navigate(`/traders/${trader.traderId}`)} // 클릭 시 이동
-                css={arrowIconStyle}
-              />
+              <MdArrowForward size={24} />
             </div>
           </div>
-        </div>
+        </Link>
       ))}
     </div>
   );
@@ -175,13 +172,6 @@ const separatorStyle = css`
 const strategyNumberStyle = css`
   ${theme.textStyle.body.body1};
   color: ${theme.colors.teal[600]};
-`;
-
-const arrowIconStyle = css`
-  cursor: pointer;
-  &:hover {
-    color: ${theme.colors.teal[600]};
-  }
 `;
 
 const emptyContainerStyle = css`

--- a/src/components/common/TraderList.tsx
+++ b/src/components/common/TraderList.tsx
@@ -10,14 +10,15 @@ interface TraderData {
   profileImage: string;
   description: string;
   strategiesCount: number;
-  followersCount: number;
+  // followersCount: number;
 }
 
 interface TraderListProps {
   traders: TraderData[];
+  badgeRank: number[];
 }
 
-const TraderList = ({ traders }: TraderListProps) => {
+const TraderList = ({ traders, badgeRank }: TraderListProps) => {
   const navigate = useNavigate();
 
   if (traders.length === 0) {
@@ -32,11 +33,13 @@ const TraderList = ({ traders }: TraderListProps) => {
     <div css={containerStyle}>
       {traders.map((trader) => (
         <div css={cardStyle} key={trader.traderId}>
-          {/* 좌측: 프로필 이미지 및 팔로워 */}
+          {/* 좌측: 프로필 이미지 및 뱃지 */}
           <div css={badgeContainerStyle}>
             <img src={trader.profileImage} alt={`${trader.name} 프로필`} css={profileImageStyle} />
-            {trader.followersCount > 0 && (
-              <div css={followerBadgeStyle}>{trader.followersCount}</div>
+            {badgeRank.includes(trader.traderId) && (
+              <div css={badgeStyle}>
+                {badgeRank.indexOf(trader.traderId) + 1} {/* 순위 계산 */}
+              </div>
             )}
           </div>
           <div css={infoContainerStyle}>
@@ -97,7 +100,7 @@ const profileImageStyle = css`
   border: 1px solid ${theme.colors.gray[300]};
 `;
 
-const followerBadgeStyle = css`
+const badgeStyle = css`
   position: absolute;
   bottom: -4px;
   right: -4px;

--- a/src/components/common/TraderList.tsx
+++ b/src/components/common/TraderList.tsx
@@ -11,6 +11,7 @@ interface TraderData {
   description: string;
   strategiesCount: number;
   // followersCount: number;
+  // createdAt: string;
 }
 
 interface TraderListProps {
@@ -78,11 +79,11 @@ const cardStyle = css`
   border-radius: 4px;
   padding: 32px;
   gap: 16px;
-  transition: outline-color ease; /* outline 효과 적용 */
+  transition: outline-color ease;
 
   &:hover {
-    outline: 2px solid ${theme.colors.teal[600]}; /* hover 시 outline 추가 */
-    outline-offset: -1px; /* border와 일치하도록 offset 설정 */
+    outline: 2px solid ${theme.colors.teal[600]};
+    outline-offset: -1px;
     cursor: pointer;
   }
 `;
@@ -162,7 +163,7 @@ const strategyCountStyle = css`
 
 const strategyTextStyle = css`
   ${theme.textStyle.body.body1};
-  color: ${theme.colors.gray[700]}; /* "전략" 텍스트 색상 */
+  color: ${theme.colors.gray[700]};
 `;
 
 const separatorStyle = css`
@@ -173,13 +174,13 @@ const separatorStyle = css`
 
 const strategyNumberStyle = css`
   ${theme.textStyle.body.body1};
-  color: ${theme.colors.teal[600]}; /* 숫자 부분의 색상 설정 */
+  color: ${theme.colors.teal[600]};
 `;
 
 const arrowIconStyle = css`
-  cursor: pointer; /* 마우스 커서 변경 */
+  cursor: pointer;
   &:hover {
-    color: ${theme.colors.teal[600]}; /* 호버 시 색상 변경 */
+    color: ${theme.colors.teal[600]};
   }
 `;
 

--- a/src/pages/trader/TraderListPage.tsx
+++ b/src/pages/trader/TraderListPage.tsx
@@ -11,77 +11,168 @@ import Select from '@/components/common/Select';
 import TraderList from '@/components/common/TraderList';
 import theme from '@/styles/theme';
 
+const desc = '관심 있는 트레이더를 찾아 전략과 프로필을 확인해보세요.';
+
 const sortOptions = [
   { label: '전략 많은 순', value: 'most_strategies' },
   { label: '신규 트레이더', value: 'new_traders' },
 ];
 
-const generateTraders = (count: number) => {
-  // 5개의 기본 데이터 정의
-  const baseTraders = [
-    {
-      traderId: 1,
-      name: '트레이더 김철수',
-      profileImage: TraderUserImage1,
-      description: '안정적인 장기 투자를 선호하는 전문 트레이더입니다.',
-      strategiesCount: 3050,
-      followersCount: 0,
-    },
-    {
-      traderId: 2,
-      name: '트레이더 닉네임 이렇게꺼지 길어져도 되는지까지 한번 보자유',
-      profileImage: TraderUserImage2,
-      description: '단기 수익을 추구하며, 높은 변동성을 활용한 전략이 특징입니다.',
-      strategiesCount: 1500,
-      followersCount: 3,
-    },
-    {
-      traderId: 3,
-      name: '내가 바로 투자 짱',
-      profileImage: TraderUserImage3,
-      description:
-        '주도주로 매매하면 수익은 크고 손실은 작다! 믿는 종목에 발등 찍힌다. 주도주로 매매하면 수익은 크고 손실은 작다! 믿는 종목에 발등 찍힌다. 내용이 길다',
-      strategiesCount: 450,
-      followersCount: 8,
-    },
-    {
-      traderId: 4,
-      name: '투자는 내꺼야',
-      profileImage: '/path/to/profile/image4.png',
-      description:
-        '투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야',
-      strategiesCount: 1200,
-      followersCount: 5,
-    },
-    {
-      traderId: 5,
-      name: '이븐하게 구워줄게요',
-      profileImage: '/path/to/profile/image5.png',
-      description: '모수에서 먹으면 냠냠 맛있어요',
-      strategiesCount: 8000,
-      followersCount: 1,
-    },
-  ];
-
-  // 기본 데이터를 반복하여 원하는 개수(count)만큼 생성
-  return Array.from({ length: count }, (_, index) => {
-    const baseIndex = index % baseTraders.length; // 0~4 반복
-    const baseTrader = baseTraders[baseIndex];
-    return {
-      ...baseTrader,
-      traderId: index + 1, // 고유 ID 부여
-    };
-  });
-};
-
-const desc = '관심 있는 트레이더를 찾아 전략과 프로필을 확인해보세요.';
+const generateTraders = [
+  {
+    traderId: 1,
+    name: '트레이더 김철수',
+    profileImage: TraderUserImage1,
+    description: '안정적인 장기 투자를 선호하는 전문 트레이더입니다.',
+    strategiesCount: 3050,
+  },
+  {
+    traderId: 2,
+    name: '트레이더 닉네임 이렇게꺼지 길어져도 되는지까지 한번 보자유',
+    profileImage: TraderUserImage2,
+    description: '단기 수익을 추구하며, 높은 변동성을 활용한 전략이 특징입니다.',
+    strategiesCount: 1500,
+  },
+  {
+    traderId: 3,
+    name: '내가 바로 투자 짱',
+    profileImage: TraderUserImage3,
+    description: '주도주로 매매하면 수익은 크고 손실은 작다! 믿는 종목에 발등 찍힌다.',
+    strategiesCount: 450,
+  },
+  {
+    traderId: 4,
+    name: '투자는 내꺼야',
+    profileImage: '/path/to/profile/image4.png',
+    description: '투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야',
+    strategiesCount: 1200,
+  },
+  {
+    traderId: 5,
+    name: '이븐하게 구워줄게요',
+    profileImage: '/path/to/profile/image5.png',
+    description: '모수에서 먹으면 냠냠 맛있어요.',
+    strategiesCount: 8000,
+  },
+  {
+    traderId: 6,
+    name: '비트코인 매니아',
+    profileImage: '/path/to/profile/image6.png',
+    description: '암호화폐 시장의 상승과 하락을 모두 잡습니다.',
+    strategiesCount: 2000,
+  },
+  {
+    traderId: 7,
+    name: '글로벌 트레이더',
+    profileImage: '/path/to/profile/image7.png',
+    description: '전 세계 다양한 시장에 투자 경험이 풍부합니다.',
+    strategiesCount: 1800,
+  },
+  {
+    traderId: 8,
+    name: '성장주 전문가',
+    profileImage: '/path/to/profile/image8.png',
+    description: '고성장 기업 발굴 전문가입니다.',
+    strategiesCount: 1450,
+  },
+  {
+    traderId: 9,
+    name: '가치주 매니저',
+    profileImage: '/path/to/profile/image9.png',
+    description: '가치투자로 장기 수익률을 극대화합니다.',
+    strategiesCount: 950,
+  },
+  {
+    traderId: 10,
+    name: '숏 트레이더',
+    profileImage: '/path/to/profile/image10.png',
+    description: '숏 포지션으로 하락장을 기회로 삼습니다.',
+    strategiesCount: 750,
+  },
+  {
+    traderId: 11,
+    name: '테마주 트레이더',
+    profileImage: '/path/to/profile/image11.png',
+    description: '시장의 핫한 테마를 선점하는 전략가입니다.',
+    strategiesCount: 2100,
+  },
+  {
+    traderId: 12,
+    name: '배당주 투자자',
+    profileImage: '/path/to/profile/image12.png',
+    description: '안정적인 배당 수익을 목표로 투자합니다.',
+    strategiesCount: 1300,
+  },
+  {
+    traderId: 13,
+    name: '주식 초보 트레이더',
+    profileImage: '/path/to/profile/image13.png',
+    description: '초보지만 꾸준히 배우며 성장 중입니다.',
+    strategiesCount: 300,
+  },
+  {
+    traderId: 14,
+    name: '옵션 트레이더',
+    profileImage: '/path/to/profile/image14.png',
+    description: '옵션 거래를 활용한 고수익 추구가 특징입니다.',
+    strategiesCount: 1150,
+  },
+  {
+    traderId: 15,
+    name: '퀀트 투자 전문가',
+    profileImage: '/path/to/profile/image15.png',
+    description: '데이터 기반의 퀀트 전략으로 투자합니다.',
+    strategiesCount: 2200,
+  },
+  {
+    traderId: 16,
+    name: '리스크 관리 전문가',
+    profileImage: '/path/to/profile/image16.png',
+    description: '리스크 최소화와 안정적 수익을 목표로 합니다.',
+    strategiesCount: 1600,
+  },
+  {
+    traderId: 17,
+    name: 'ETF 트레이더',
+    profileImage: '/path/to/profile/image17.png',
+    description: 'ETF로 다양한 시장에 손쉽게 투자합니다.',
+    strategiesCount: 1400,
+  },
+  {
+    traderId: 18,
+    name: '크립토 고수',
+    profileImage: '/path/to/profile/image18.png',
+    description: '암호화폐에서 최적의 투자 전략을 구사합니다.',
+    strategiesCount: 1850,
+  },
+  {
+    traderId: 19,
+    name: '펀드 매니저',
+    profileImage: '/path/to/profile/image19.png',
+    description: '펀드 관리 경험이 풍부한 투자자입니다.',
+    strategiesCount: 2800,
+  },
+  {
+    traderId: 20,
+    name: '기술주 애호가',
+    profileImage: '/path/to/profile/image20.png',
+    description: '첨단 기술 관련 주식에 주로 투자합니다.',
+    strategiesCount: 1950,
+  },
+];
 
 const TraderListPage = () => {
-  const traders = generateTraders(75); // 50명의 가상 트레이더 데이터 생성
+  const traders = generateTraders;
   const [page, setPage] = useState(1);
   const limit = 14; // 한 페이지당 2칸씩*7줄
   const totalPages = Math.ceil(traders.length / limit);
   const currentPageData = traders.slice((page - 1) * limit, page * limit);
+
+  // strategiesCount 기준으로 상위 10명을 식별
+  const badgeRank = [...traders]
+    .sort((a, b) => b.strategiesCount - a.strategiesCount) // strategiesCount 내림차순 정렬
+    .slice(0, 10) // 상위 10명만 추출
+    .map((trader) => trader.traderId); // 상위 10명의 traderId 저장
 
   useEffect(() => {
     window.scrollTo(0, 0); // 페이지 변경 시 스크롤 맨 위로 이동
@@ -98,13 +189,13 @@ const TraderListPage = () => {
           <Select
             options={sortOptions}
             onChange={() => {}}
-            defaultLabel='전략 많은 순'
+            defaultLabel='기본 등록 순'
             type='sm'
             width='160px'
           />
         </div>
         <div css={listContainerStyle}>
-          <TraderList traders={currentPageData} />
+          <TraderList traders={currentPageData} badgeRank={badgeRank} />
           <Pagination totalPage={totalPages} limit={limit} page={page} setPage={setPage} />
         </div>
       </div>

--- a/src/pages/trader/TraderListPage.tsx
+++ b/src/pages/trader/TraderListPage.tsx
@@ -25,6 +25,7 @@ const generateTraders = [
     profileImage: TraderUserImage1,
     description: '안정적인 장기 투자를 선호하는 전문 트레이더입니다.',
     strategiesCount: 3050,
+    createdAt: '2024-11-01',
   },
   {
     traderId: 2,
@@ -32,6 +33,7 @@ const generateTraders = [
     profileImage: TraderUserImage2,
     description: '단기 수익을 추구하며, 높은 변동성을 활용한 전략이 특징입니다.',
     strategiesCount: 1500,
+    createdAt: '2024-04-27',
   },
   {
     traderId: 3,
@@ -39,6 +41,7 @@ const generateTraders = [
     profileImage: TraderUserImage3,
     description: '주도주로 매매하면 수익은 크고 손실은 작다! 믿는 종목에 발등 찍힌다.',
     strategiesCount: 450,
+    createdAt: '2024-05-02',
   },
   {
     traderId: 4,
@@ -46,6 +49,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image4.png',
     description: '투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야',
     strategiesCount: 1200,
+    createdAt: '2024-10-07',
   },
   {
     traderId: 5,
@@ -53,6 +57,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image5.png',
     description: '모수에서 먹으면 냠냠 맛있어요.',
     strategiesCount: 8000,
+    createdAt: '2024-03-20',
   },
   {
     traderId: 6,
@@ -60,6 +65,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image6.png',
     description: '암호화폐 시장의 상승과 하락을 모두 잡습니다.',
     strategiesCount: 2000,
+    createdAt: '2024-06-15',
   },
   {
     traderId: 7,
@@ -67,6 +73,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image7.png',
     description: '전 세계 다양한 시장에 투자 경험이 풍부합니다.',
     strategiesCount: 1800,
+    createdAt: '2024-07-19',
   },
   {
     traderId: 8,
@@ -74,6 +81,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image8.png',
     description: '고성장 기업 발굴 전문가입니다.',
     strategiesCount: 1450,
+    createdAt: '2024-08-13',
   },
   {
     traderId: 9,
@@ -81,6 +89,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image9.png',
     description: '가치투자로 장기 수익률을 극대화합니다.',
     strategiesCount: 950,
+    createdAt: '2024-02-14',
   },
   {
     traderId: 10,
@@ -88,6 +97,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image10.png',
     description: '숏 포지션으로 하락장을 기회로 삼습니다.',
     strategiesCount: 750,
+    createdAt: '2024-11-01',
   },
   {
     traderId: 11,
@@ -95,6 +105,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image11.png',
     description: '시장의 핫한 테마를 선점하는 전략가입니다.',
     strategiesCount: 2100,
+    createdAt: '2024-01-22',
   },
   {
     traderId: 12,
@@ -102,6 +113,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image12.png',
     description: '안정적인 배당 수익을 목표로 투자합니다.',
     strategiesCount: 1300,
+    createdAt: '2024-05-27',
   },
   {
     traderId: 13,
@@ -109,6 +121,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image13.png',
     description: '초보지만 꾸준히 배우며 성장 중입니다.',
     strategiesCount: 300,
+    createdAt: '2024-03-08',
   },
   {
     traderId: 14,
@@ -116,6 +129,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image14.png',
     description: '옵션 거래를 활용한 고수익 추구가 특징입니다.',
     strategiesCount: 1150,
+    createdAt: '2024-06-01',
   },
   {
     traderId: 15,
@@ -123,6 +137,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image15.png',
     description: '데이터 기반의 퀀트 전략으로 투자합니다.',
     strategiesCount: 2200,
+    createdAt: '2024-10-20',
   },
   {
     traderId: 16,
@@ -130,6 +145,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image16.png',
     description: '리스크 최소화와 안정적 수익을 목표로 합니다.',
     strategiesCount: 1600,
+    createdAt: '2024-04-02',
   },
   {
     traderId: 17,
@@ -137,6 +153,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image17.png',
     description: 'ETF로 다양한 시장에 손쉽게 투자합니다.',
     strategiesCount: 1400,
+    createdAt: '2024-09-25',
   },
   {
     traderId: 18,
@@ -144,6 +161,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image18.png',
     description: '암호화폐에서 최적의 투자 전략을 구사합니다.',
     strategiesCount: 1850,
+    createdAt: '2024-07-05',
   },
   {
     traderId: 19,
@@ -151,6 +169,7 @@ const generateTraders = [
     profileImage: '/path/to/profile/image19.png',
     description: '펀드 관리 경험이 풍부한 투자자입니다.',
     strategiesCount: 2800,
+    createdAt: '2024-08-23',
   },
   {
     traderId: 20,
@@ -158,24 +177,36 @@ const generateTraders = [
     profileImage: '/path/to/profile/image20.png',
     description: '첨단 기술 관련 주식에 주로 투자합니다.',
     strategiesCount: 1950,
+    createdAt: '2024-02-07',
   },
 ];
 
 const TraderListPage = () => {
   const traders = generateTraders;
   const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState('');
   const limit = 14; // 한 페이지당 2칸씩*7줄
   const totalPages = Math.ceil(traders.length / limit);
-  const currentPageData = traders.slice((page - 1) * limit, page * limit);
+
+  const sortedTraders = [...traders].sort((a, b) => {
+    if (sortBy === 'most_strategies') {
+      return b.strategiesCount - a.strategiesCount; // 전략 많은 순으로 정렬
+    } else if (sortBy === 'new_traders') {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(); // 등록일 내림차순
+    }
+    return 0;
+  });
+
+  const currentPageData = sortedTraders.slice((page - 1) * limit, page * limit);
 
   // strategiesCount 기준으로 상위 10명을 식별
   const badgeRank = [...traders]
-    .sort((a, b) => b.strategiesCount - a.strategiesCount) // strategiesCount 내림차순 정렬
-    .slice(0, 10) // 상위 10명만 추출
-    .map((trader) => trader.traderId); // 상위 10명의 traderId 저장
+    .sort((a, b) => b.strategiesCount - a.strategiesCount)
+    .slice(0, 10)
+    .map((trader) => trader.traderId);
 
   useEffect(() => {
-    window.scrollTo(0, 0); // 페이지 변경 시 스크롤 맨 위로 이동
+    window.scrollTo(0, 0);
   }, [page]);
 
   return (
@@ -188,7 +219,7 @@ const TraderListPage = () => {
           </div>
           <Select
             options={sortOptions}
-            onChange={() => {}}
+            onChange={(option) => setSortBy(option.value)}
             defaultLabel='기본 등록 순'
             type='sm'
             width='160px'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

반복된 데이터 말고 20개의 데이터로 필터링 하는 걸 적용하느라 코드가 깁니다..

뱃지 형태
 뱃지는 전략 많은 순으로 1위 ~ 10위까지 부여
`  // strategiesCount 기준으로 상위 10명을 식별
  const badgeRank = [...traders]
    .sort((a, b) => b.strategiesCount - a.strategiesCount)
    .slice(0, 10)
    .map((trader) => trader.traderId);`

필터링구분
 - 전략 많은 순으로 필터링 될 수 있게 만들기
 - 신규트레이더순으로 필터링 될 수 있게 만들기
 - (신규트레이더순) traderId 순으로 등록되어질 것 같은데, createdAt을 추가하여 등록날짜 기준으로 정렬되게 하였습니다. 
 

페이지 이동
 아이콘 클릭 -> 전체칸 클릭 으로 수정
 -  슬랙에 권장사항보고 Link로 페이지 이동하게 하였습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/a82c8265-50b6-4594-9dfa-aa85e27a9536)
![image](https://github.com/user-attachments/assets/eade463c-b410-4dab-94aa-f76c1022f12f)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

트레이더 목록 페이지를 개선하여 전략 수와 등록 날짜에 따라 트레이더를 정렬할 수 있는 필터링 옵션을 추가합니다. 전략 수를 기준으로 상위 10명의 트레이더에 대한 배지 랭킹 시스템을 구현합니다. 페이지 전환을 위한 링크를 사용하도록 내비게이션을 업데이트합니다.

새로운 기능:
- 전략 수에 따라 트레이더를 정렬하고 등록 날짜를 기준으로 새로운 트레이더를 정렬할 수 있는 필터링 옵션을 추가합니다.

개선 사항:
- 전략 수를 기준으로 상위 10명의 트레이더에 대한 배지 랭킹을 구현합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the trader list page by adding filtering options for sorting traders by strategy count and registration date. Implement a badge ranking system for the top 10 traders based on strategy count. Update navigation to use links for page transitions.

New Features:
- Add filtering options to sort traders by the number of strategies and by new traders based on registration date.

Enhancements:
- Implement badge ranking for the top 10 traders based on the number of strategies.

</details>