### PR TITLE
fix: 닉네임 중복 검사 로직 수정 (#182)

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -7,9 +7,11 @@ export const REGEX = {
   email: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
   // 닉네임: 영문 대소문자와 숫자 조합 필수, 2-10자 사이, 공백 불가능 ✅
   nickname: {
-    onlyAlphanumeric: /^[a-zA-Z0-9]+$/, // 영문자와 숫자만 허용
-    hasNumber: /[0-9]/, // 숫자 포함
-    hasLetter: /[a-zA-Z]/, // 영문자 포함
+    korean: /[가-힣]/, // 한글 포함 여부
+    upperEnglish: /[A-Z]/, // 영어 대문자 포함 여부
+    lowerEnglish: /[a-z]/, // 영어 소문자 포함 여부
+    number: /[0-9]/, // 숫자 포함 여부
+    allowedChars: /^[가-힣A-Za-z0-9]+$/, // 허용된 문자만 포함
   },
   // 비밀번호: 영문, 숫자, 특수문자 포함 8자 이상
   password: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
@@ -28,8 +30,7 @@ export const VALIDATION_MESSAGE = {
   nickname: {
     length: '닉네임은 2-10자 사이여야 합니다.',
     whitespace: '공백은 사용할 수 없습니다.',
-    charset: '영문 대소문자와 숫자만 사용 가능합니다.',
-    combination: '영문자와 숫자를 반드시 함께 사용해야 합니다.',
+    chars: '한글, 영문 대소문자, 숫자만 사용 가능합니다.',
     valid: '유효한 닉네임입니다.',
   },
   password: {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -13,6 +13,7 @@ export const validateEmail = (value: string) => ({
 
 // 닉네임 유효성 검사 함수 수정본
 export const validateNickname = (nickname: string) => {
+  // 길이 검사
   if (nickname.length < 2 || nickname.length > 10) {
     return {
       isValid: false,
@@ -20,7 +21,7 @@ export const validateNickname = (nickname: string) => {
     };
   }
 
-  // 공백검사
+  // 공백 검사
   if (REGEX.whitespace.test(nickname)) {
     return {
       isValid: false,
@@ -28,20 +29,27 @@ export const validateNickname = (nickname: string) => {
     };
   }
 
-  // 영문자와 숫자로만 구성되었는지 검사할게!
-  if (!REGEX.nickname.onlyAlphanumeric.test(nickname)) {
+  // 허용된 문자만 포함되어 있는지 검사
+  if (!REGEX.nickname.allowedChars.test(nickname)) {
     return {
       isValid: false,
-      message: VALIDATION_MESSAGE.nickname.charset,
+      message: VALIDATION_MESSAGE.nickname.chars,
     };
   }
-  // 숫자와 영문자가 모두 포함되었는지 검사할게!
-  const hasNumber = REGEX.nickname.hasNumber.test(nickname);
-  const hasLetter = REGEX.nickname.hasLetter.test(nickname);
-  if (!hasNumber || !hasLetter) {
+
+  // 최소한 한가지 이상의 타입이 포함되어 있어야 함
+  const containsKorean = REGEX.nickname.korean.test(nickname);
+  const containsUpper = REGEX.nickname.upperEnglish.test(nickname);
+  const containsLower = REGEX.nickname.lowerEnglish.test(nickname);
+  const containsNumber = REGEX.nickname.number.test(nickname);
+
+  // 최소한 하나의 문자 타입은 포함되어야 함
+  const hasValidChars = containsKorean || containsUpper || containsLower || containsNumber;
+
+  if (!hasValidChars) {
     return {
       isValid: false,
-      message: VALIDATION_MESSAGE.nickname.combination,
+      message: VALIDATION_MESSAGE.nickname.chars,
     };
   }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

정규식 패턴 재정의:

- korean: 한글 포함 여부 검사
- upperEnglish: 영어 대문자 포함 여부 검사
- lowerEnglish: 영어 소문자 포함 여부 검사
- number: 숫자 포함 여부 검사
- allowedChars: 허용된 문자만 포함하는지 검사

유효성 검사 로직:

- 길이 검사 (2-10자)
- 공백 포함 여부 검사
- 허용된 문자만 포함되어 있는지 검사
- 최소한 하나의 문자 타입이 포함되어 있는지 검사
- 특수문자 불가

가능한 모든 조합 허용:

- 한글만
- 영어 대문자만
- 영어 소문자만
- 숫자만
- 위 네 가지의 모든 가능한 조합 (2개, 3개, 4개 조합 모두 가능)

✅ 다음과 같은 닉네임을 모두 허용

- 단일 타입: "홍길동", "ABC", "abc", "123"
- 2가지 조합: "Hong길동", "abc123", "홍길동3"
- 3가지 조합: "Hong길3", "a홍A3", "123Ab홍"
- 4가지 조합: "홍aA3", "1aA홍"

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

버그 수정:
- 닉네임 유효성 검사 로직을 수정하여 한국어 문자, 대문자 및 소문자 영어 문자, 숫자를 포함한 더 넓은 범위의 문자 조합을 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix nickname validation logic to allow a wider range of character combinations, including Korean characters, uppercase and lowercase English letters, and numbers.

</details>