### PR TITLE
[feat] 리뷰(전략상세하단) CSS 스타일링

### DIFF
--- a/src/components/page/strategy-detail/review/ReviewInputList.tsx
+++ b/src/components/page/strategy-detail/review/ReviewInputList.tsx
@@ -8,19 +8,19 @@ import theme from '@/styles/theme';
 
 interface Review {
   id: number;
-  writerId: string; // 작성자 ID
-  profileImg: string; // 프로필 이미지 URL
+  writerId: string;
+  profileImg: string;
   content: string;
   date: string;
 }
 
 interface ReviewInputListProps {
-  reviews: Review[]; // 부모에서 전달받은 리뷰 데이터
+  reviews: Review[];
   writerId: string;
   profileImg: string;
-  onAddReview: (newReview: Review) => void; // 리뷰 추가 콜백
-  onEditReview: (id: number, updatedContent: string) => void; // 리뷰 수정 콜백
-  onDeleteReview: (id: number) => void; // 리뷰 삭제 콜백
+  onAddReview: (newReview: Review) => void;
+  onEditReview: (id: number, updatedContent: string) => void;
+  onDeleteReview: (id: number) => void;
 }
 
 const ReviewInputList = ({
@@ -34,25 +34,25 @@ const ReviewInputList = ({
   const [inputValue, setInputValue] = useState('');
 
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value); // 입력값 업데이트
+    setInputValue(e.target.value);
   };
 
   const handleAddButtonClick = () => {
     if (!inputValue.trim()) return;
 
-    // 새로운 리뷰 생성
+    // 리뷰 등록
     const newReview: Review = {
-      id: Date.now(), // 고유 ID 생성
-      writerId, // 작성자 ID
-      profileImg, // 기본 프로필 이미지 경로
+      id: Date.now(),
+      writerId,
+      profileImg,
       content: inputValue.trim(),
-      date: new Date().toISOString().split('T')[0], // 현재 날짜
+      date: new Date().toISOString().split('T')[0],
     };
 
-    setInputValue(''); // 입력 필드 초기화
+    setInputValue('');
 
     if (onAddReview) {
-      onAddReview(newReview); // 콜백 호출
+      onAddReview(newReview);
     }
   };
 
@@ -71,31 +71,13 @@ const ReviewInputList = ({
           variant='primary'
           size='sm'
           width={110}
-          disabled={!inputValue.trim()} // 입력값이 없을 경우 버튼 비활성화
-          onClick={handleAddButtonClick} // 등록 버튼 클릭 시 동작
+          disabled={!inputValue.trim()}
+          onClick={handleAddButtonClick}
         >
           등록
         </Button>
       </div>
 
-      {/* 리뷰 리스트 */}
-      {/* <div css={reviewListStyle}>
-        {reviews.map((review) => (
-          <div key={review.id} css={reviewItemStyle}>
-            <img src={review.profileImg} alt='프로필 이미지' css={avatarStyle} />
-            <div>
-              <div css={reviewHeaderStyle}>
-                <span css={userNameStyle}>{review.writerId}</span>
-                <span css={dateStyle}>{review.date}</span>
-              </div>
-              <p css={reviewContentStyle}>{review.content}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}; */}
       <div css={reviewListStyle}>
         {reviews.map((review) => (
           <ReviewItem

--- a/src/components/page/strategy-detail/review/ReviewInputList.tsx
+++ b/src/components/page/strategy-detail/review/ReviewInputList.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import Button from '@/components/common/Button';
+import ReviewItem from '@/components/page/strategy-detail/review/ReviewItem';
+import theme from '@/styles/theme';
+
+interface Review {
+  id: number;
+  writerId: string; // 작성자 ID
+  profileImg: string; // 프로필 이미지 URL
+  content: string;
+  date: string;
+}
+
+interface ReviewInputListProps {
+  reviews: Review[]; // 부모에서 전달받은 리뷰 데이터
+  writerId: string;
+  profileImg: string;
+  onAddReview: (newReview: Review) => void; // 리뷰 추가 콜백
+  onEditReview: (id: number, updatedContent: string) => void; // 리뷰 수정 콜백
+  onDeleteReview: (id: number) => void; // 리뷰 삭제 콜백
+}
+
+const ReviewInputList = ({
+  reviews,
+  writerId,
+  profileImg,
+  onAddReview,
+  onEditReview,
+  onDeleteReview,
+}: ReviewInputListProps) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value); // 입력값 업데이트
+  };
+
+  const handleAddButtonClick = () => {
+    if (!inputValue.trim()) return;
+
+    // 새로운 리뷰 생성
+    const newReview: Review = {
+      id: Date.now(), // 고유 ID 생성
+      writerId, // 작성자 ID
+      profileImg, // 기본 프로필 이미지 경로
+      content: inputValue.trim(),
+      date: new Date().toISOString().split('T')[0], // 현재 날짜
+    };
+
+    setInputValue(''); // 입력 필드 초기화
+
+    if (onAddReview) {
+      onAddReview(newReview); // 콜백 호출
+    }
+  };
+
+  return (
+    <div>
+      {/* 리뷰 입력창 */}
+      <div css={inputContainerStyle}>
+        <input
+          type='text'
+          value={inputValue}
+          onChange={onInputChange}
+          placeholder='내용을 입력해주세요'
+          css={inputStyle}
+        />
+        <Button
+          variant='primary'
+          size='sm'
+          width={110}
+          disabled={!inputValue.trim()} // 입력값이 없을 경우 버튼 비활성화
+          onClick={handleAddButtonClick} // 등록 버튼 클릭 시 동작
+        >
+          등록
+        </Button>
+      </div>
+
+      {/* 리뷰 리스트 */}
+      {/* <div css={reviewListStyle}>
+        {reviews.map((review) => (
+          <div key={review.id} css={reviewItemStyle}>
+            <img src={review.profileImg} alt='프로필 이미지' css={avatarStyle} />
+            <div>
+              <div css={reviewHeaderStyle}>
+                <span css={userNameStyle}>{review.writerId}</span>
+                <span css={dateStyle}>{review.date}</span>
+              </div>
+              <p css={reviewContentStyle}>{review.content}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}; */}
+      <div css={reviewListStyle}>
+        {reviews.map((review) => (
+          <ReviewItem
+            key={review.id}
+            review={review}
+            writerId={writerId}
+            onEdit={onEditReview || (() => {})}
+            onDelete={onDeleteReview || (() => {})}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const inputContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const inputStyle = css`
+  ${theme.textStyle.body.body3};
+  flex: 1;
+  resize: none;
+  height: ${theme.input.height.md};
+  padding: ${theme.input.padding.md};
+  font-size: ${theme.input.fontSize.md};
+  border: 1px solid ${theme.colors.gray[300]};
+  outline: none;
+  transition: all 0.2s ease;
+
+  &::placeholder {
+    color: ${theme.colors.gray[700] + '4a'};
+  }
+
+  &:hover {
+    border-color: ${theme.colors.main.primary};
+  }
+
+  &:focus {
+    border-color: ${theme.colors.main.primary};
+  }
+`;
+
+const reviewListStyle = css`
+  margin-top: 24px;
+`;
+
+export default ReviewInputList;

--- a/src/components/page/strategy-detail/review/ReviewInputList.tsx
+++ b/src/components/page/strategy-detail/review/ReviewInputList.tsx
@@ -68,7 +68,7 @@ const ReviewInputList = ({
           css={inputStyle}
         />
         <Button
-          variant='primary'
+          variant='accent'
           size='sm'
           width={110}
           disabled={!inputValue.trim()}

--- a/src/components/page/strategy-detail/review/ReviewItem.tsx
+++ b/src/components/page/strategy-detail/review/ReviewItem.tsx
@@ -15,23 +15,22 @@ interface Review {
 interface ReviewItemProps {
   review: Review;
   writerId: string;
-  onEdit: (id: number, updatedContent: string) => void; // 수정 콜백
-  onDelete: (id: number) => void; // 삭제 콜백
+  onEdit: (id: number, updatedContent: string) => void;
+  onDelete: (id: number) => void;
 }
 
 const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => {
-  const [isEditing, setIsEditing] = useState(false); // 수정 모드 상태
-  const [updatedContent, setUpdatedContent] = useState(review.content); // 수정된 리뷰 내용
-
+  const [isEditing, setIsEditing] = useState(false);
+  const [updatedContent, setUpdatedContent] = useState(review.content);
   const handleEdit = () => {
     if (isEditing) {
-      onEdit(review.id, updatedContent); // 수정 내용 저장
+      onEdit(review.id, updatedContent);
     }
-    setIsEditing(!isEditing); // 수정 모드 토글
+    setIsEditing(!isEditing);
   };
 
   const handleDelete = () => {
-    onDelete(review.id); // 삭제 실행
+    onDelete(review.id);
   };
 
   return (
@@ -43,7 +42,7 @@ const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => 
             <span css={userNameStyle}>{review.writerId}</span>
             <span css={dateStyle}>{review.date}</span>
           </div>
-          {review.writerId === writerId && ( // 작성자가 본인일 때만 버튼 표시
+          {review.writerId === writerId && (
             <div css={reviewActionsStyle}>
               <button css={actionButtonStyle} onClick={handleEdit}>
                 {isEditing ? '완료' : '수정'}
@@ -99,7 +98,7 @@ const headerStyle = css`
 const userInfoStyle = css`
   display: flex;
   align-items: center;
-  gap: 8px; /* 닉네임과 날짜 사이의 간격 */
+  gap: 8px;
 `;
 
 const userNameStyle = css`
@@ -110,7 +109,7 @@ const userNameStyle = css`
 const dateStyle = css`
   ${theme.textStyle.captions.caption2};
   color: ${theme.colors.gray[400]};
-  margin-right: auto; /* 버튼을 오른쪽으로 밀기 위한 설정 */
+  margin-right: auto;
 `;
 
 const reviewActionsStyle = css`

--- a/src/components/page/strategy-detail/review/ReviewItem.tsx
+++ b/src/components/page/strategy-detail/review/ReviewItem.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+interface Review {
+  id: number;
+  writerId: string;
+  profileImg: string;
+  content: string;
+  date: string;
+}
+
+interface ReviewItemProps {
+  review: Review;
+  writerId: string;
+  onEdit: (id: number, updatedContent: string) => void; // 수정 콜백
+  onDelete: (id: number) => void; // 삭제 콜백
+}
+
+const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => {
+  const [isEditing, setIsEditing] = useState(false); // 수정 모드 상태
+  const [updatedContent, setUpdatedContent] = useState(review.content); // 수정된 리뷰 내용
+
+  const handleEdit = () => {
+    if (isEditing) {
+      onEdit(review.id, updatedContent); // 수정 내용 저장
+    }
+    setIsEditing(!isEditing); // 수정 모드 토글
+  };
+
+  const handleDelete = () => {
+    onDelete(review.id); // 삭제 실행
+  };
+
+  return (
+    <div css={reviewItemStyle}>
+      <img src={review.profileImg} alt='프로필 이미지' css={profileStyle} />
+      <div css={contentStyle}>
+        <div css={headerStyle}>
+          <div css={userInfoStyle}>
+            <span css={userNameStyle}>{review.writerId}</span>
+            <span css={dateStyle}>{review.date}</span>
+          </div>
+          {review.writerId === writerId && ( // 작성자가 본인일 때만 버튼 표시
+            <div css={reviewActionsStyle}>
+              <button css={actionButtonStyle} onClick={handleEdit}>
+                {isEditing ? '완료' : '수정'}
+              </button>
+              <span css={separatorStyle}></span>
+              <button css={actionButtonStyle} onClick={handleDelete}>
+                삭제
+              </button>
+            </div>
+          )}
+        </div>
+        {isEditing ? (
+          <textarea
+            value={updatedContent}
+            onChange={(e) => setUpdatedContent(e.target.value)}
+            css={textareaStyle}
+          />
+        ) : (
+          <p css={reviewContentStyle}>{review.content}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const reviewItemStyle = css`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border-bottom: 1px solid ${theme.colors.gray[200]};
+  padding: 16px 0;
+`;
+
+const profileStyle = css`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid ${theme.colors.gray[100]};
+`;
+
+const contentStyle = css`
+  flex: 1;
+  margin-right: 92px;
+`;
+
+const headerStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const userInfoStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px; /* 닉네임과 날짜 사이의 간격 */
+`;
+
+const userNameStyle = css`
+  ${theme.textStyle.body.body1};
+  color: ${theme.colors.gray[900]};
+`;
+
+const dateStyle = css`
+  ${theme.textStyle.captions.caption2};
+  color: ${theme.colors.gray[400]};
+  margin-right: auto; /* 버튼을 오른쪽으로 밀기 위한 설정 */
+`;
+
+const reviewActionsStyle = css`
+  display: flex;
+  gap: 4px;
+`;
+
+const actionButtonStyle = css`
+  ${theme.buttons.label.sm};
+  color: ${theme.colors.gray[500]};
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: ${theme.colors.gray[900]};
+  }
+`;
+
+const separatorStyle = css`
+  background: ${theme.colors.gray[300]};
+  width: 1px;
+  height: 18px;
+`;
+
+const textareaStyle = css`
+  width: 100%;
+  height: 60px;
+  margin-top: 8px;
+  padding: 8px;
+  font-size: ${theme.textStyle.body.body3};
+  border: 1px solid ${theme.colors.gray[300]};
+  border-radius: 4px;
+  resize: none;
+  outline: none;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: ${theme.colors.main.primary};
+  }
+
+  &:focus {
+    border-color: ${theme.colors.main.primary};
+  }
+`;
+
+const reviewContentStyle = css`
+  ${theme.textStyle.body.body3};
+  margin-top: 4px;
+`;
+
+export default ReviewItem;

--- a/src/components/page/strategy-detail/review/ReviewSection.tsx
+++ b/src/components/page/strategy-detail/review/ReviewSection.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 
 import { css } from '@emotion/react';
@@ -15,7 +14,7 @@ interface Review {
   date: string;
 }
 
-const itemsPerPage = 5; // 한 페이지에 표시할 리뷰 수
+const itemsPerPage = 5;
 
 const ReviewSection = () => {
   const [reviews, setReviews] = useState<Review[]>([
@@ -33,14 +32,16 @@ const ReviewSection = () => {
       content: '워메워메',
       date: '2024-11-24',
     },
-  ]); // 전체 리뷰 데이터
-  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
+  ]);
+
+  // 전체 리뷰 데이터
+  const [currentPage, setCurrentPage] = useState(1);
 
   const writerId = '내가 투자 짱';
 
   // 리뷰 추가 시 호출될 함수
   const handleAddReview = (newReview: Review) => {
-    setReviews((prevReviews) => [newReview, ...prevReviews]); // 새로운 리뷰 추가
+    setReviews((prevReviews) => [newReview, ...prevReviews]);
   };
 
   // 리뷰 수정 시 호출될 함수
@@ -71,21 +72,21 @@ const ReviewSection = () => {
 
       {/* 리뷰 입력 및 표시 */}
       <ReviewInputList
-        reviews={displayedReviews} // 현재 페이지의 리뷰 전달
+        reviews={displayedReviews}
         writerId={writerId}
         profileImg='https://via.placeholder.com/40'
-        onAddReview={handleAddReview} // 새로운 리뷰 추가 핸들러 전달
-        onEditReview={handleEditReview} // 리뷰 수정 핸들러 전달
-        onDeleteReview={handleDeleteReview} // 리뷰 삭제 핸들러 전달
+        onAddReview={handleAddReview}
+        onEditReview={handleEditReview}
+        onDeleteReview={handleDeleteReview}
       />
 
       {/* 페이지네이션 */}
       <div css={PaginationStyle}>
         <Pagination
-          totalPage={Math.ceil(reviews.length / itemsPerPage)} // 총 페이지 수 계산
+          totalPage={Math.ceil(reviews.length / itemsPerPage)}
           limit={itemsPerPage}
           page={currentPage}
-          setPage={setCurrentPage} // 페이지 변경 핸들러
+          setPage={setCurrentPage}
         />
       </div>
     </div>

--- a/src/components/page/strategy-detail/review/ReviewSection.tsx
+++ b/src/components/page/strategy-detail/review/ReviewSection.tsx
@@ -1,0 +1,124 @@
+/** @jsxImportSource @emotion/react */
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import Pagination from '@/components/common/Pagination';
+import ReviewInputList from '@/components/page/strategy-detail/review/ReviewInputList';
+import theme from '@/styles/theme';
+
+interface Review {
+  id: number;
+  writerId: string;
+  profileImg: string;
+  content: string;
+  date: string;
+}
+
+const itemsPerPage = 5; // 한 페이지에 표시할 리뷰 수
+
+const ReviewSection = () => {
+  const [reviews, setReviews] = useState<Review[]>([
+    {
+      id: 1,
+      writerId: '내가 투자 짱',
+      profileImg: 'https://via.placeholder.com/40',
+      content: '우와 대박 쩔어용',
+      date: '2024-11-25',
+    },
+    {
+      id: 2,
+      writerId: '너님이 투자 짱',
+      profileImg: 'https://via.placeholder.com/40',
+      content: '워메워메',
+      date: '2024-11-24',
+    },
+  ]); // 전체 리뷰 데이터
+  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
+
+  const writerId = '내가 투자 짱';
+
+  // 리뷰 추가 시 호출될 함수
+  const handleAddReview = (newReview: Review) => {
+    setReviews((prevReviews) => [newReview, ...prevReviews]); // 새로운 리뷰 추가
+  };
+
+  // 리뷰 수정 시 호출될 함수
+  const handleEditReview = (id: number, updatedContent: string) => {
+    setReviews((prevReviews) =>
+      prevReviews.map((review) =>
+        review.id === id ? { ...review, content: updatedContent } : review
+      )
+    );
+  };
+
+  // 리뷰 삭제 시 호출될 함수
+  const handleDeleteReview = (id: number) => {
+    setReviews((prevReviews) => prevReviews.filter((review) => review.id !== id));
+  };
+
+  // 현재 페이지의 리뷰 데이터 계산
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const displayedReviews = reviews.slice(startIndex, endIndex);
+
+  return (
+    <div css={containerStyle}>
+      <div css={headerStyle}>
+        <h2 css={titleStyle}>리뷰</h2>
+        <span css={countStyle}>{reviews.length}</span>
+      </div>
+
+      {/* 리뷰 입력 및 표시 */}
+      <ReviewInputList
+        reviews={displayedReviews} // 현재 페이지의 리뷰 전달
+        writerId={writerId}
+        profileImg='https://via.placeholder.com/40'
+        onAddReview={handleAddReview} // 새로운 리뷰 추가 핸들러 전달
+        onEditReview={handleEditReview} // 리뷰 수정 핸들러 전달
+        onDeleteReview={handleDeleteReview} // 리뷰 삭제 핸들러 전달
+      />
+
+      {/* 페이지네이션 */}
+      <div css={PaginationStyle}>
+        <Pagination
+          totalPage={Math.ceil(reviews.length / itemsPerPage)} // 총 페이지 수 계산
+          limit={itemsPerPage}
+          page={currentPage}
+          setPage={setCurrentPage} // 페이지 변경 핸들러
+        />
+      </div>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  width: 100%;
+  max-width: ${theme.layout.width.content};
+  padding: 40px 40px 56px 40px;
+  background-color: ${theme.colors.main.white};
+`;
+
+const headerStyle = css`
+  display: flex;
+  align-items: center;
+  margin-bottom: 26px;
+  gap: 4px;
+`;
+
+const titleStyle = css`
+  ${theme.textStyle.subtitles.subtitle1};
+`;
+
+const countStyle = css`
+  ${theme.textStyle.subtitles.subtitle1};
+  color: ${theme.colors.main.primary};
+`;
+
+const PaginationStyle = css`
+  display: flex;
+  flex-direction: column;
+  margin-top: 24px;
+`;
+
+export default ReviewSection;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import Modal from '@/components/common/Modal';
 import FileDownSection from '@/components/page/strategy-detail/FileDownSection';
 import IconTagSection from '@/components/page/strategy-detail/IconTagSection';
+import ReviewSection from '@/components/page/strategy-detail/review/ReviewSection';
 import ChartSection from '@/components/page/strategy-detail/section/ChartSection';
 import StrategyContent from '@/components/page/strategy-detail/StrategyContent';
 import StrategyHeader from '@/components/page/strategy-detail/StrategyHeader';
@@ -327,6 +328,9 @@ const StrategyDetailPage = () => {
           </div>
         </div>
       </div>
+      <div css={reviewSectionWrapper}>
+        <ReviewSection />
+      </div>
       <Modal />
     </div>
   );
@@ -334,6 +338,8 @@ const StrategyDetailPage = () => {
 
 const containerStyle = css`
   display: flex;
+  flex-direction: column;
+  align-items: center;
   background-color: ${theme.colors.gray[100]};
   justify-content: center;
   flex-shrink: 0;
@@ -354,6 +360,11 @@ const contentWrapper = css`
   display: flex;
   align-items: left;
   flex-direction: column;
+`;
+
+const reviewSectionWrapper = css`
+  width: ${theme.layout.width.content};
+  margin: 16px 0 76px 0;
 `;
 
 export default StrategyDetailPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

리뷰(전략상세하단) CSS 스타일링
 - 수정, 삭제 부분은 마우스 올리면 글씨가 진해집니다. (primary로 바뀌어야하는건지 문의드립니다!)
 - 리뷰 5개를 넘어가면 페이지네이션으로 다름 페이지로 넘어갑니다. 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/ba1630b5-016b-43c1-9993-acc34ccf90ff)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

전략 세부 페이지에 리뷰를 추가, 편집 및 삭제할 수 있는 기능을 갖춘 리뷰 섹션을 추가합니다. 리뷰가 다섯 개 이상일 때 표시를 관리하기 위해 페이지 매김을 구현합니다.

새로운 기능:
- 사용자가 리뷰를 추가, 편집 및 삭제할 수 있는 전략 세부 페이지에 새로운 리뷰 섹션을 도입합니다.

개선 사항:
- 리뷰가 다섯 개 이상일 때 효율적으로 처리할 수 있도록 리뷰 섹션에 페이지 매김을 구현합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a review section to the strategy detail page with functionality for adding, editing, and deleting reviews. Implement pagination to manage the display of reviews when there are more than five.

New Features:
- Introduce a new review section in the strategy detail page, allowing users to add, edit, and delete reviews.

Enhancements:
- Implement pagination for the review section to handle more than five reviews efficiently.

</details>