### PR TITLE
[Refactor] responsive input 개선 #214

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -14,7 +14,7 @@ export type IconPosition = 'left' | 'right';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputSize?: InputSize;
-  width?: string;
+  width?: string | number;
   status?: InputStatus;
   leftIcon?: 'mail' | 'key' | 'search';
   rightIcon?: 'eye' | 'clear';
@@ -29,7 +29,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const {
     inputSize = 'md',
-    width = '444px',
+    width = '100%',
     status = 'default',
     leftIcon,
     rightIcon,
@@ -99,6 +99,20 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     setShowPassword((prev) => !prev);
   };
 
+  // width 값을 처리하는 함수 추가
+  const getWidthStyle = (width: string | number) => {
+    if (typeof width === 'number') {
+      return `width: ${width}px;`;
+    }
+    return width;
+  };
+
+  // container 스타일에 width를 동적으로 적용
+  const currentContainerStyles = css`
+    ${containerStyles};
+    width: ${getWidthStyle(width)};
+  `;
+
   // input 상태에 따른 스타일 적용
   const currentInputStyles = [
     baseInputStyles, // 기본 input 스타일
@@ -111,7 +125,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   ];
 
   return (
-    <div css={containerStyles}>
+    <div css={[containerStyles, currentContainerStyles]}>
       <div css={[wrapperStyles, iconSpacingStyles[inputSize]]}>
         {leftIcon && <div css={leftIconStyles}>{getIcon(leftIcon)}</div>}
 
@@ -145,7 +159,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
 Input.displayName = 'Input';
 
 const containerStyles = css`
-  display: inline-block;
+  display: block;
   position: relative;
 `;
 
@@ -153,6 +167,7 @@ const wrapperStyles = css`
   position: relative;
   display: flex;
   align-items: center;
+  width: 100%;
 `;
 
 const baseInputStyles = css`

--- a/src/pages/auth/signup/SignUpSelectTypePage.tsx
+++ b/src/pages/auth/signup/SignUpSelectTypePage.tsx
@@ -18,7 +18,7 @@ const SignUpSelectTypePage = () => {
 
   const handleSignup = (role: UserRole) => {
     console.log(role);
-    navigate(ROUTES.AUTH.SIGNUP.FORM, { state: { userRole: addRolePrefix(role) } }); // HomeRouteState 타입에 맞게 객체로 전달(investor, trader)
+    navigate(ROUTES.AUTH.SIGNUP.FORM, { state: { userRole: addRolePrefix(role) } });
   };
 
   return (

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,6 @@
 // Role_ 제거 후 대문자로 변환 : 예) ROLE_INVESTOR -> INVESTOR
-export const formatRole = (role: string) => role.replace('ROLE_', '').toUpperCase();
+export const formatRole = (role: string) => role.replace('MEMBER_ROLE_', '').toUpperCase();
 
 // Role_ 추가 후 대문자로 변환 : 예) investor -> ROLE_INVESTOR
 export const addRolePrefix = (role: string) =>
-  role.startsWith('ROLE_') ? role : `ROLE_${role.toUpperCase()}`;
+  role.startsWith('MEMBER_ROLE_') ? role : `MEMBER_ROLE_${role.toUpperCase()}`;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

```tsx
// 픽셀 단위로 사용
<Input width="500px" />

// 퍼센트로 사용
<Input width="100%" />

// width prop을 생략하면 자동으로 100%
<Input />

// 부모 컴포넌트에서 제어
<div style={{ width: '500px' }}>
  <Input width="100%" />
</div>

```

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

Input 컴포넌트를 리팩토링하여 너비를 문자열 또는 숫자로 지정할 수 있도록 하여 반응성을 향상시키고, 지정되지 않은 경우 기본적으로 100% 너비로 설정합니다. 컨테이너의 디스플레이 스타일을 블록으로 조정하고 동적 너비 적용을 보장합니다. 새로운 접두사 표준을 수용하기 위해 역할 포맷팅 함수를 수정합니다.

향상된 기능:
- Input 컴포넌트를 리팩토링하여 너비를 문자열 또는 숫자로 지원하여 더 유연한 스타일링 옵션을 허용합니다.
- 너비 속성이 지정되지 않은 경우 Input 컴포넌트를 기본적으로 100% 너비로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Input component to enhance its responsiveness by allowing width to be specified as a string or number, and defaulting to 100% width when unspecified. Adjust the display style of the container to block and ensure dynamic width application. Modify role formatting functions to accommodate a new prefix standard.

Enhancements:
- Refactor the Input component to support width as a string or number, allowing more flexible styling options.
- Update the Input component to default to 100% width when the width prop is not specified.

</details>