### PR TITLE
feat: 비밀번호 찾기 페이지 API 연동 (#223) - 완성

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -29,7 +29,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const {
     inputSize = 'md',
-    width = '100%',
+    width = 'auto',
     status = 'default',
     leftIcon,
     rightIcon,

--- a/src/components/page/signup/VerificationInput.tsx
+++ b/src/components/page/signup/VerificationInput.tsx
@@ -87,6 +87,7 @@ const VerificationInput = ({
       <Input
         type='text'
         inputSize='lg'
+        width='100%'
         placeholder='메일로 받은 인증번호 입력'
         onChange={(e) => onChange(e.target.value)}
         value={value}
@@ -114,7 +115,6 @@ const inputContainerStyle = css`
   position: relative;
 `;
 const inputStyle = css`
-  width: 288px;
   padding-right: 60px;
 
   &:hover:not(:disabled) {

--- a/src/pages/auth/find/FindPasswordPage.tsx
+++ b/src/pages/auth/find/FindPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
+import { AxiosError } from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
 
 import tickImage from '@/assets/images/tick.svg';
@@ -8,6 +9,10 @@ import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import VerificationInput from '@/components/page/signup/VerificationInput';
 import { ROUTES } from '@/constants/routes';
+import {
+  useRequestVerificationMutation,
+  useVerifyAdminCodeMutation,
+} from '@/hooks/mutations/useVerifacationMutation';
 import theme from '@/styles/theme';
 import { validateCode, validateEmail } from '@/utils/validation';
 
@@ -18,9 +23,12 @@ const FindPasswordPage = () => {
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [resetTimer, setResetTimer] = useState<number>(0); // 타이머 리셋을 위한 상태
   const [isInputDisabled, setIsInputDisabled] = useState(true); // 페이지 로드 시 입력창 비활성화
-  const [serverVerificationCode, setServerVerificationCode] = useState<string>(''); // 서버에서 받은 인증번호 저장
+  const [isVerificationActive, setIsVerificationActive] = useState(true);
   // 인증 요청버튼 클릭했는지 여부 추적하는 NEW 상태
   const [isVerficationRequested, setIsVerificationRequested] = useState(false);
+
+  const { mutate: requestVerificationCode } = useRequestVerificationMutation();
+  const { mutate: verifyCode } = useVerifyAdminCodeMutation();
 
   // verificationCode가 변경될 때마다 실행
   useEffect(() => {
@@ -45,17 +53,22 @@ const FindPasswordPage = () => {
 
     // 이메일 인증 요청 로직
     try {
-      // const response = await requestVerificationEmail();
-      // setServerVerificationCode(response.verificationCode); // 서버 응답에서 인증번호 저장
-      // 테스트용 코드
-      setServerVerificationCode('123456'); // 테스트를 위해 하드코딩
-      // 인증 요청 성공 시 상태 업데이트
-      setIsVerificationRequested(true);
-      // 인증번호 요청 성공 시, isVerificationActive를 토글 => 타이머 재시작!
-      setResetTimer((prev) => prev + 1); // 타이머 리셋(타이머 시작트리거)
-      setIsInputDisabled(false); // 입력창 활성화
-      setErrorMessage(''); // 에러 메시지 초기화
-      setVerificationCode(''); // 인증코드 입력값 초기화
+      // 이메일로 인증번호 요청 API 호출
+      requestVerificationCode(undefined, {
+        onSuccess: () => {
+          setVerificationCode(''); // 인증번호 초기화
+          setErrorMessage(''); // 에러메시지 초기화
+          setIsVerificationActive(true); // 인증 활성화
+          setResetTimer((prev) => prev + 1); // 타이머 리셋
+          setIsInputDisabled(false); // 입력창 활성화
+          setIsVerificationRequested(true); // 타이머 시작을 위한 상태 활성화 추가
+        },
+        onError: () => {
+          setErrorMessage('인증번호 발송에 실패했습니다.');
+          setIsVerificationActive(false); // 인증 비활성화
+          setIsVerificationRequested(false); // 타이머 시작을 위한 상태 비활성화 추가
+        },
+      });
     } catch (error) {
       setErrorMessage('인증번호 발송에 실패했습니다.');
     }
@@ -69,22 +82,26 @@ const FindPasswordPage = () => {
       setErrorMessage('인증 시간이 만료되었습니다. 다시 시도해주세요.');
       return;
     }
-
-    // 1. 유효성 검사 통과 여부
-    // 2. 서버에서 받은 인증번호와 일치 여부
-    // 조건을 단계별로 체크
-    if (validationResult.isValid) {
-      // 6자리 숫자 형식은 맞지만, 서버의 인증번호와 다른 경우
-      if (verificationCode !== serverVerificationCode) {
-        setErrorMessage('올바른 인증번호가 아닙니다.');
-      } else {
-        // 모든 조건 충족
-        navigate(ROUTES.AUTH.FIND.PASSWORD_RESET);
-      }
-    } else {
-      // 6자리 숫자 형식이 아닌 경우
+    if (!validationResult.isValid) {
       setErrorMessage(validationResult.message);
+      return;
     }
+    verifyCode(verificationCode, {
+      onSuccess: (response) => {
+        if (response.status === 'success') {
+          navigate(ROUTES.AUTH.FIND.PASSWORD_RESET, { replace: true });
+        } else {
+          setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
+        }
+      },
+      onError: (error: AxiosError) => {
+        if (error.response?.status === 401) {
+          setErrorMessage('올바른 인증번호가 아닙니다.');
+        } else {
+          setErrorMessage('인증 처리 중 오류가 발생했습니다.');
+        }
+      },
+    });
   };
 
   // 확인버튼 활성화 조건을 검사하는 함수

--- a/src/pages/auth/find/FindPasswordPage.tsx
+++ b/src/pages/auth/find/FindPasswordPage.tsx
@@ -39,6 +39,7 @@ const FindPasswordPage = () => {
   }, [verificationCode]);
 
   const handleEmailVerification = () => {
+    console.log(isVerificationActive);
     // 이메일 입력값 확인
     if (!email) {
       setErrorMessage('이메일을 입력해주세요.');


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 이메일 인증번호 요청 API 연동
- 이메일 인증번호 확인 API 연동
- 현재 500 에러가 발생하는데, 서버에서 확인 필요
- MSW에서는 정상적으로 잘 동작함(완료!!!)
- 추후 테스트 필요 ✅

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

비밀번호 복구 페이지에 이메일 인증을 위한 API를 통합하여 사용자가 이메일 코드를 요청하고 인증할 수 있도록 합니다. 페이지를 리팩토링하여 API 응답을 효과적으로 처리하고 사용자 피드백과 상호작용을 개선합니다.

새로운 기능:
- 비밀번호 복구 페이지에 이메일 인증 코드 요청 및 인증 API 통합.

개선 사항:
- 이메일 인증을 위한 API 성공 및 오류 응답을 처리하도록 비밀번호 복구 페이지를 리팩토링.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate API for email verification in the password recovery page, allowing users to request and verify email codes. Refactor the page to handle API responses effectively, improving user feedback and interaction.

New Features:
- Integrate email verification code request and verification API into the password recovery page.

Enhancements:
- Refactor the password recovery page to handle API success and error responses for email verification.

</details>