### PR TITLE
fix: 이메일 인증요청, 인증확인 파라미터 추가 (#223)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -109,10 +109,11 @@ export const findEmail = async (phone: string) => {
 };
 
 // 이메일로 인증번호를 요청하는 API
-export const requestVerificationCode = async (): Promise<ApiResponse<null>> => {
+export const requestVerificationCode = async (email: string): Promise<ApiResponse<null>> => {
+  console.log('Request body:', { email }); // 요청 바디 로깅
   const response = await apiClient.post<ApiResponse<null>>(
     API_ENDPOINTS.AUTH.EMAIL.REQUEST_VERIFICATION,
-    {},
+    { email },
     {
       headers: {
         useMock: import.meta.env.VITE_ENABLE_MSW === 'true', // MSW 사용 시 true
@@ -123,10 +124,14 @@ export const requestVerificationCode = async (): Promise<ApiResponse<null>> => {
 };
 
 // 입력한 인증번호 검증 API (기존 코드)
-export const verifyCode = async (code: string): Promise<ApiResponse<{ expires_at: string }>> => {
+export const verifyCode = async (
+  email: string,
+  code: string
+): Promise<ApiResponse<{ expires_at: string }>> => {
+  console.log('Request body:', { email, code });
   const response = await apiClient.post<ApiResponse<{ expires_at: string }>>(
     API_ENDPOINTS.AUTH.EMAIL.CHECK_VERIFICATION, // 이메일 인증 API 경로(사용자, 관리자 공통)
-    { code },
+    { email, code },
     {
       headers: {
         useMock: import.meta.env.VITE_ENABLE_MSW === 'true', // MSW 사용 시 true

--- a/src/hooks/mutations/useAdminVerifyMutation.ts
+++ b/src/hooks/mutations/useAdminVerifyMutation.ts
@@ -11,9 +11,13 @@ export const useAdminVerifyMutation = () => {
   const { setAdminAuth } = useAdminAuthStore();
   const { user } = useAuthStore();
 
-  return useMutation<ApiResponse<{ expires_at: string }>, AxiosError, string>({
-    mutationFn: async (code: string) => {
-      const response = await verifyCode(code);
+  return useMutation<
+    ApiResponse<{ expires_at: string }>,
+    AxiosError,
+    { email: string; code: string }
+  >({
+    mutationFn: async ({ email, code }) => {
+      const response = await verifyCode(email, code);
       if (response.status === 'success' && user && isAdminUser(user)) {
         // 기존 adminAuth 상태를 업데이트
         setAdminAuth({

--- a/src/hooks/mutations/useVerifacationMutation.tsx
+++ b/src/hooks/mutations/useVerifacationMutation.tsx
@@ -6,12 +6,12 @@ import { ApiResponse } from '@/types/auth';
 
 // 인증번호 요청 mutation
 export const useRequestVerificationMutation = () =>
-  useMutation<ApiResponse<null>, AxiosError>({
+  useMutation<ApiResponse<null>, AxiosError, string>({
     mutationFn: requestVerificationCode,
   });
 
 // 인증번호 검증 mutation
 export const useVerifyAdminCodeMutation = () =>
-  useMutation<ApiResponse<{ expires_at: string }>, AxiosError, string>({
-    mutationFn: verifyCode,
+  useMutation<ApiResponse<{ expires_at: string }>, AxiosError, { email: string; code: string }>({
+    mutationFn: ({ email, code }) => verifyCode(email, code),
   });

--- a/src/pages/auth/admin/AdminVerifyPage.tsx
+++ b/src/pages/auth/admin/AdminVerifyPage.tsx
@@ -12,11 +12,15 @@ import {
   useRequestVerificationMutation,
   useVerifyAdminCodeMutation,
 } from '@/hooks/mutations/useVerifacationMutation';
+import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
 import { validateCode } from '@/utils/validation';
 
 const AdminVerifyPage = () => {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
+  // 관리자 이메일
+  const email = user?.email || '';
   const [verificationCode, setVerificationCode] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [resetTimer, setResetTimer] = useState<number>(0); // 타이머 리셋을 위한 상태
@@ -57,7 +61,7 @@ const AdminVerifyPage = () => {
     // setState는 비동기이므로, 이 시점에서는 아직 errorMessage가 변경되지 않았음
     try {
       // 이메일로 인증번호 요청 API 호출
-      requestVerificationCode(undefined, {
+      requestVerificationCode(email, {
         onSuccess: () => {
           setVerificationCode(''); // 인증번호 초기화
           setErrorMessage(''); // 에러메시지 초기화
@@ -90,22 +94,25 @@ const AdminVerifyPage = () => {
       setErrorMessage(validationResult.message);
       return;
     }
-    verifyCode(verificationCode, {
-      onSuccess: (response) => {
-        if (response.status === 'success') {
-          navigate(ROUTES.ADMIN.STRATEGY.APPROVAL, { replace: true });
-        } else {
-          setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
-        }
-      },
-      onError: (error: AxiosError) => {
-        if (error.response?.status === 401) {
-          setErrorMessage('올바른 인증번호가 아닙니다.');
-        } else {
-          setErrorMessage('인증 처리 중 오류가 발생했습니다.');
-        }
-      },
-    });
+    verifyCode(
+      { email, code: verificationCode },
+      {
+        onSuccess: (response) => {
+          if (response.status === 'success') {
+            navigate(ROUTES.ADMIN.STRATEGY.APPROVAL, { replace: true });
+          } else {
+            setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
+          }
+        },
+        onError: (error: AxiosError) => {
+          if (error.response?.status === 401) {
+            setErrorMessage('올바른 인증번호가 아닙니다.');
+          } else {
+            setErrorMessage('인증 처리 중 오류가 발생했습니다.');
+          }
+        },
+      }
+    );
   };
   return (
     <div css={containerStyle}>

--- a/src/pages/auth/find/FindPasswordPage.tsx
+++ b/src/pages/auth/find/FindPasswordPage.tsx
@@ -55,7 +55,7 @@ const FindPasswordPage = () => {
     // 이메일 인증 요청 로직
     try {
       // 이메일로 인증번호 요청 API 호출
-      requestVerificationCode(undefined, {
+      requestVerificationCode(email, {
         onSuccess: () => {
           setVerificationCode(''); // 인증번호 초기화
           setErrorMessage(''); // 에러메시지 초기화
@@ -87,22 +87,25 @@ const FindPasswordPage = () => {
       setErrorMessage(validationResult.message);
       return;
     }
-    verifyCode(verificationCode, {
-      onSuccess: (response) => {
-        if (response.status === 'success') {
-          navigate(ROUTES.AUTH.FIND.PASSWORD_RESET, { replace: true });
-        } else {
-          setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
-        }
-      },
-      onError: (error: AxiosError) => {
-        if (error.response?.status === 401) {
-          setErrorMessage('올바른 인증번호가 아닙니다.');
-        } else {
-          setErrorMessage('인증 처리 중 오류가 발생했습니다.');
-        }
-      },
-    });
+    verifyCode(
+      { email, code: verificationCode },
+      {
+        onSuccess: (response) => {
+          if (response.status === 'success') {
+            navigate(ROUTES.AUTH.FIND.PASSWORD_RESET, { replace: true });
+          } else {
+            setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
+          }
+        },
+        onError: (error: AxiosError) => {
+          if (error.response?.status === 401) {
+            setErrorMessage('올바른 인증번호가 아닙니다.');
+          } else {
+            setErrorMessage('인증 처리 중 오류가 발생했습니다.');
+          }
+        },
+      }
+    );
   };
 
   // 확인버튼 활성화 조건을 검사하는 함수


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 이메일 인증요청, 인증확인 파라미터 추가
- 이메일 인증요청 시 이메일을 파라미터로 전달
- 이메일 인증확인 시 이메일, 인증번호를 파라미터로 전달
- 현재 500 에러 발생
- 비밀번호 찾기페이지와, 관리자 이메일 인증페이지에 적용

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

버그 수정:
- 이메일 인증 과정에서 이메일과 인증 코드가 매개변수로 전달되지 않아 500 오류가 발생하던 문제를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where email and verification code were not being passed as parameters in the email verification process, which was causing a 500 error.

</details>