### PR TITLE
[Feat] formdata 전송을 위한 apiClient 수정 (#244)

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -34,5 +34,6 @@ export const API_ENDPOINTS = {
   INQUIRY: '/api/consultations', // 나의 문의
   FILES: {
     PROFILE: (fileId: string) => `/api/files/profile/${fileId}`, // 프로필 이미지 다운로드
+    PROPOSAL: '/api/files/proposal', // 제안서 파일 업로드
   },
 };

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -1,7 +1,11 @@
-import { apiClient } from './apiClient';
+import { apiClient, createFormDataRequest } from './apiClient';
 import { API_ENDPOINTS } from './apiEndpoints';
 
-import { InputDailyAnalysisProps } from '@/types/strategyDetail';
+import {
+  FileUploadOptions,
+  FileUploadResponse,
+  InputDailyAnalysisProps,
+} from '@/types/strategyDetail';
 
 //전략 상세 기본 정보 조회
 export const fetchDefaultStrategyDetail = async (id: number) => {
@@ -132,5 +136,31 @@ export const fetchStatistics = async (strategyId: number) => {
     return res.data;
   } catch (error) {
     console.error('fetch to failed Monthly Analysis', error);
+  }
+};
+
+// 제안서 파일 업로드 전용 함수
+export const uploadProposalFile = async (
+  options: FileUploadOptions
+): Promise<FileUploadResponse> => {
+  const formData = createFormDataRequest({
+    file: options.file,
+  });
+
+  try {
+    const response = await apiClient.post<FileUploadResponse>(
+      API_ENDPOINTS.FILES.PROPOSAL,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          Auth: options.authType,
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('제안서 업로드 실패:', error);
+    throw error;
   }
 };

--- a/src/types/strategyDetail.ts
+++ b/src/types/strategyDetail.ts
@@ -72,3 +72,19 @@ export interface StatisticsProps {
   profitFactor: number;
   roa: number;
 }
+
+// API 응답 타입 정의
+export interface FileUploadResponse {
+  fileId: string;
+  fileUrl: string;
+  displayName: string;
+  message: string;
+}
+// Auth 타입 정의
+type AuthType = 'Admin' | 'Trader';
+
+// 파일 업로드 옵션 타입 정의
+export interface FileUploadOptions {
+  file: File;
+  authType: AuthType;
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 제안서 업로드 apiEndpoints 추가
- apiClient에 formdata 전송 기능 추가
  - 폼데이터 요청을 위한 헬퍼 함수
  - 인터셉터에 폼데이터 전송 기능 추가
    - FormData인 경우 Content-Type 헤더 자동 설정
- 제안서 파일 업로드 전용 함수 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

apiClient를 수정하여 FormData 전송을 지원하고, FormData 요청 생성을 위한 새로운 헬퍼 함수와 자동 Content-Type 헤더 설정을 포함합니다. 제안서 업로드를 위한 새로운 API 엔드포인트를 추가하고 제안서 파일 업로드를 위한 기능을 구현합니다.

새로운 기능:
- apiEndpoints 구성에 제안서 업로드를 위한 새로운 API 엔드포인트 추가.
- 파일 업로드를 용이하게 하기 위해 FormData 요청을 생성하는 헬퍼 함수 도입.
- 새로운 FormData 헬퍼를 사용하여 제안서 파일을 업로드하는 전용 기능 구현.

개선 사항:
- FormData를 전송할 때 Content-Type 헤더를 'multipart/form-data'로 자동 설정하도록 apiClient를 개선.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the apiClient to support FormData transmission, including a new helper function for creating FormData requests and automatic Content-Type header setting. Add a new API endpoint for proposal uploads and implement a function for uploading proposal files.

New Features:
- Add a new API endpoint for proposal uploads in the apiEndpoints configuration.
- Introduce a helper function for creating FormData requests to facilitate file uploads.
- Implement a dedicated function for uploading proposal files using the new FormData helper.

Enhancements:
- Enhance the apiClient to automatically set the Content-Type header to 'multipart/form-data' when sending FormData.

</details>