### PR TITLE
[design] 트레이더 마이페이지 전략 스타일링

### DIFF
--- a/src/pages/mypage/trader/TraderMyPage.tsx
+++ b/src/pages/mypage/trader/TraderMyPage.tsx
@@ -140,17 +140,6 @@ const StrategyEmptyStyle = css`
   text-align: center;
 `;
 
-const folderInfoStyle = css`
-  color: ${theme.colors.gray[500]};
-  text-align: right;
-  font-weight: 400;
-  margin-bottom: 4px;
-
-  span {
-    color: ${theme.colors.gray[700]};
-  }
-`;
-
 const tableWrapperStyle = css`
   display: flex;
   flex-direction: column;

--- a/src/pages/mypage/trader/TraderMyPage.tsx
+++ b/src/pages/mypage/trader/TraderMyPage.tsx
@@ -1,28 +1,100 @@
+import { useEffect, useState } from 'react';
+
 import { css } from '@emotion/react';
 import { Link } from 'react-router-dom';
 
+import AnalyticsGraph from '@/assets/images/analytics_graph.png';
+import futureIcon from '@/assets/images/producttype_futures.png';
+import StockIcon from '@/assets/images/producttype_stock.png';
+import TradeTypeHIcon from '@/assets/images/tradetype_H.png';
+import TradeTypePIcon from '@/assets/images/tradetype_P.png';
+import Pagination from '@/components/common/Pagination';
+import StrategyList from '@/components/common/StrategyList';
 import { ROUTES } from '@/constants/routes';
 import theme from '@/styles/theme';
 
-const TraderMyPage = () => (
-  <div css={myPageWrapperStyle}>
-    <div css={myPageHeaderStyle}>
-      <div>
-        <h2>나의 전략</h2>
-        <p>
-          총 <span>0</span>개의 전략이 있습니다
-        </p>
+const generateStrategies = (count: number) => {
+  const titles = [
+    '지수 선물 상품을 활용한 전략',
+    '단기 수익을 위한 변동성 전략',
+    '사람들 많이 살 때 따라사는 전략 입니다. 두줄로 되면 이런식으로 되고 어쩌구저쩌구 배고파',
+    '크리스마스때 시작하면 대박나는 전략',
+    '우리에게 주말은 없다 전략',
+    '장기 투자로 안정적 수익을 추구하는 전략',
+    'AI를 활용한 초단타 매매 전략',
+    '월급쟁이를 위한 안정적 투자법',
+    '대기업 주식만 따라 사는 전략',
+    '한 달에 한 번 매매하는 전략',
+  ];
+
+  const generateIcons = () => {
+    const icons = [futureIcon, StockIcon];
+    return Array.from(
+      { length: Math.ceil(Math.random() * 5) },
+      () => icons[Math.floor(Math.random() * icons.length)]
+    );
+  };
+
+  return Array.from({ length: count }, (_, index) => ({
+    strategyId: index + 1,
+    strategyTitle: titles[Math.floor(Math.random() * titles.length)],
+    analytics_graph: AnalyticsGraph,
+    tradingTypeIcon: TradeTypeHIcon,
+    cycleIcon: TradeTypePIcon,
+    investmentAssetClassesIcon: generateIcons(),
+    writerId: Math.ceil(Math.random() * 10),
+    cumulativeReturn: parseFloat((Math.random() * 20 - 10).toFixed(2)),
+    oneYearReturn: parseFloat((Math.random() * 15 - 5).toFixed(2)),
+    mdd: Math.floor(Math.random() * 20000000 - 10000000),
+    smscore: parseFloat((Math.random() * 100).toFixed(2)),
+    followers_count: Math.floor(Math.random() * 5000),
+  }));
+};
+
+const TraderMyPage = () => {
+  const strategies = generateStrategies(80);
+  const [page, setPage] = useState(1);
+  const limit = 5;
+  const totalPages = Math.ceil(strategies.length / limit);
+  const currentPageData = strategies.slice((page - 1) * limit, page * limit);
+  const startRank = (page - 1) * limit + 1;
+
+  useEffect(() => {
+    console.log(currentPageData.length);
+  }, []);
+
+  return (
+    <div css={myPageWrapperStyle}>
+      <div css={myPageHeaderStyle}>
+        <div>
+          <h2>나의 전략</h2>
+          <p>
+            총 <span>0</span>개의 전략이 있습니다
+          </p>
+        </div>
+        <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.CREATE}>전략등록</Link>
       </div>
-      <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.CREATE}>전략등록</Link>
+      <div>
+        {currentPageData.length === 0 ? (
+          <p css={StrategyEmptyStyle}>
+            아직 등록된 전략이 없습니다.
+            <br /> &apos;전략 등록&apos; 버튼을 눌러 새로운 전략을 추가해보세요!
+          </p>
+        ) : (
+          <div css={tableWrapperStyle}>
+            <StrategyList
+              strategies={currentPageData}
+              startRank={startRank}
+              containerWidth='875px'
+              gridTemplate='minmax(0, 2.91fr) minmax(0, 2.29fr) minmax(0, 1.6fr) minmax(0, 1.37fr) minmax(0, 0.91fr) minmax(0, 0.91fr)'
+            />
+            <Pagination totalPage={totalPages} limit={limit} page={page} setPage={setPage} />
+          </div>
+        )}
+      </div>
     </div>
-    <div>
-      <p css={StrategyEmptyStyle}>
-        아직 등록된 전략이 없습니다.
-        <br /> &apos;전략 등록&apos; 버튼을 눌러 새로운 전략을 추가해보세요!
-      </p>
-    </div>
-  </div>
-);
+  );
+};
 
 const myPageWrapperStyle = css`
   width: 955px;
@@ -66,6 +138,24 @@ const StrategyEmptyStyle = css`
   height: 200px;
   color: ${theme.colors.gray[400]};
   text-align: center;
+`;
+
+const folderInfoStyle = css`
+  color: ${theme.colors.gray[500]};
+  text-align: right;
+  font-weight: 400;
+  margin-bottom: 4px;
+
+  span {
+    color: ${theme.colors.gray[700]};
+  }
+`;
+
+const tableWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 56px;
 `;
 
 export default TraderMyPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #199

## 📋 작업 내용
수민킴이 한 거... 숟가락으로 떠줘서 먹었습니다...
api 연결은 추후....
![image](https://github.com/user-attachments/assets/a00ce74e-2e81-4f7f-b726-1ea7c76686a3)


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="1391" alt="스크린샷 2024-11-29 오후 2 34 40" src="https://github.com/user-attachments/assets/f4f0d422-bb7b-4524-9086-cbba9408ed45">


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Summary by Sourcery

Trader MyPage의 전략 목록에 페이지 매김을 구현하고 사용자 인터페이스 개선을 위해 모의 데이터 생성을 추가하여 개선합니다.

개선 사항:
- Trader MyPage의 전략 목록에 페이지 매김을 구현하여 사용자가 여러 페이지의 전략을 탐색할 수 있도록 합니다.
- Trader MyPage에 표시할 모의 전략 데이터를 생성하는 기능을 추가하여 샘플 콘텐츠로 사용자 인터페이스를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the Trader MyPage by implementing pagination for the strategy list and adding mock data generation for improved user interface.

Enhancements:
- Implement pagination for the strategy list on the Trader MyPage, allowing users to navigate through multiple pages of strategies.
- Add a function to generate mock strategy data for display on the Trader MyPage, enhancing the user interface with sample content.

</details>