### PR TITLE
[feat] 전략상세페이지 Auth 값에따라 다른 버튼상태

### DIFF
--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -5,7 +5,9 @@ import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button';
 import { ROUTES } from '@/constants/routes';
+import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
+import { UserRole } from '@/types/route';
 
 interface StrategyHeaderProps {
   id: number;
@@ -15,10 +17,21 @@ interface StrategyHeaderProps {
 
 export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps) => {
   const navigate = useNavigate();
+  const { user } = useAuthStore(); // store에서 user 정보 가져오기
 
   const handleMoveEditPage = (id: string) => {
     navigate(`${ROUTES.MYPAGE.TRADER.STRATEGIES.EDIT(id)}`);
   };
+
+  const handleInquiryPage = () => {
+    navigate(`${ROUTES.STRATEGY.INQUIRIES}`);
+  };
+
+  const handleFollowingPage = () => {
+    navigate(`${ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS}`);
+  };
+
+  const userRole = user?.role as UserRole; // 유저 지정
 
   return (
     <div css={actionAreaStyle}>
@@ -26,24 +39,50 @@ export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps
         <GiCircle size={40} css={circleStyle} />
         <MdOutlineShare size={16} css={shareStyle} />
       </button>
-      <div css={buttonAreaStyle}>
-        <Button size='xs' variant='secondaryGray' width={90} onClick={() => onDelete(id)}>
-          삭제
-        </Button>
-        <Button
-          size='xs'
-          variant='neutral'
-          width={90}
-          onClick={() => {
-            handleMoveEditPage(String(id));
-          }}
-        >
-          수정
-        </Button>
-        <Button size='xs' width={120} onClick={onApproval}>
-          승인요청
-        </Button>
-      </div>
+      {userRole === 'ROLE_TRADER' ? ( // 사용자 역할이 'ROLE_TRADER'(트레이더)인 경우
+        <div css={buttonAreaStyle}>
+          <Button size='xs' variant='secondaryGray' width={90} onClick={() => onDelete(id)}>
+            삭제
+          </Button>
+          <Button
+            size='xs'
+            variant='neutral'
+            width={90}
+            onClick={() => {
+              handleMoveEditPage(String(id));
+            }}
+          >
+            수정
+          </Button>
+          <Button size='xs' width={120} onClick={onApproval}>
+            승인요청
+          </Button>
+        </div>
+      ) : (
+        // 사용자 역할이 'INVESTOR'(투자자)인 경우 -> 기본값!!!
+        <div css={buttonAreaStyle}>
+          <Button
+            size='sm'
+            variant='accent'
+            width={114}
+            onClick={() => {
+              handleInquiryPage();
+            }}
+          >
+            문의하기
+          </Button>
+          <Button
+            size='sm'
+            variant='primary'
+            width={124}
+            onClick={() => {
+              handleFollowingPage();
+            }}
+          >
+            전략 팔로우
+          </Button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

트레이더와 투자자별로 다르게 나타내는 전략상세 버튼
주석많을거에요! 그건 나중에 지울게요!!!! 


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/a763dddd-cfec-47cf-ac7d-5eb21aea2343)
![image](https://github.com/user-attachments/assets/258e90c4-e94d-4f16-845e-e974d46d7921)
![image](https://github.com/user-attachments/assets/6304bd8f-5bdb-4b10-abca-6d30b6a0e4d2)
![image](https://github.com/user-attachments/assets/6d7719d9-00ca-4192-acd0-ad9d8917d237)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

새로운 기능:
- 전략 세부 페이지에서 역할 기반 버튼 표시를 구현하여 트레이더와 투자자에게 다른 버튼을 보여줍니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Implement role-based button display on the strategy detail page, showing different buttons for traders and investors.

</details>