### PR TITLE
[feat] 전략상세페이지 데이터를 State로 문의등록페이지에 데이터 연결하기

### DIFF
--- a/src/components/page/inquiry-create/InquiryCreateForm.tsx
+++ b/src/components/page/inquiry-create/InquiryCreateForm.tsx
@@ -9,12 +9,18 @@ import InquiryStrategyInfo from '@/components/page/inquiry-create/inquiry-form-c
 import InquiryTitle from '@/components/page/inquiry-create/inquiry-form-content/InquiryTitle';
 import { ROUTES } from '@/constants/routes';
 
-const generateInquiry = {
-  strategyId: '1',
-  strategyName: '사람들이 살 때 많이 따라사는 전략',
-};
+// const generateInquiry = {
+//   strategyId: '1',
+//   strategyName: '사람들이 살 때 많이 따라사는 전략',
+// };
 
-const InquiryCreateForm = () => {
+interface InquiryCreateFormProps {
+  strategyTitle: string;
+  strategyId: string;
+  traderId: string;
+}
+
+const InquiryCreateForm = ({ strategyTitle, strategyId, traderId }: InquiryCreateFormProps) => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -32,7 +38,7 @@ const InquiryCreateForm = () => {
   return (
     <form css={formContainerStyle}>
       <InquiryStrategyInfo
-        strategyName={generateInquiry.strategyName}
+        strategyName={strategyTitle}
         investmentAmount={investmentAmount}
         onAmountChange={(e) => setInvestmentAmount(e.target.value)}
         investmentDate={investmentDate}

--- a/src/components/page/inquiry-create/InquiryCreateForm.tsx
+++ b/src/components/page/inquiry-create/InquiryCreateForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
@@ -15,11 +15,8 @@ interface InquiryCreateFormProps {
   traderId: string;
 }
 
-const InquiryCreateForm = ({
-  strategyTitle,
-  strategyId,
-  traderId = '71-88RZ_QQ65hMGknyWKLA', // 기본값 설정
-}: InquiryCreateFormProps) => {
+// const InquiryCreateForm = ({ strategyTitle, strategyId, traderId }: InquiryCreateFormProps) => {
+const InquiryCreateForm = ({ strategyTitle, strategyId }: InquiryCreateFormProps) => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');

--- a/src/components/page/inquiry-create/InquiryCreateForm.tsx
+++ b/src/components/page/inquiry-create/InquiryCreateForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
@@ -15,7 +15,11 @@ interface InquiryCreateFormProps {
   traderId: string;
 }
 
-const InquiryCreateForm = ({ strategyTitle }: InquiryCreateFormProps) => {
+const InquiryCreateForm = ({
+  strategyTitle,
+  strategyId,
+  traderId = '71-88RZ_QQ65hMGknyWKLA', // 기본값 설정
+}: InquiryCreateFormProps) => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -27,7 +31,7 @@ const InquiryCreateForm = ({ strategyTitle }: InquiryCreateFormProps) => {
   };
 
   const handleStrategyDetailClick = () => {
-    navigate(ROUTES.STRATEGY.DETAIL('strategyId'));
+    navigate(ROUTES.STRATEGY.DETAIL(strategyId));
   };
 
   return (

--- a/src/components/page/inquiry-create/InquiryCreateForm.tsx
+++ b/src/components/page/inquiry-create/InquiryCreateForm.tsx
@@ -9,18 +9,13 @@ import InquiryStrategyInfo from '@/components/page/inquiry-create/inquiry-form-c
 import InquiryTitle from '@/components/page/inquiry-create/inquiry-form-content/InquiryTitle';
 import { ROUTES } from '@/constants/routes';
 
-// const generateInquiry = {
-//   strategyId: '1',
-//   strategyName: '사람들이 살 때 많이 따라사는 전략',
-// };
-
 interface InquiryCreateFormProps {
   strategyTitle: string;
   strategyId: string;
   traderId: string;
 }
 
-const InquiryCreateForm = ({ strategyTitle, strategyId, traderId }: InquiryCreateFormProps) => {
+const InquiryCreateForm = ({ strategyTitle }: InquiryCreateFormProps) => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -35,23 +35,12 @@ export const StrategyHeader = ({
   const handleInquiryPage = () => {
     navigate(`${ROUTES.STRATEGY.INQUIRIES}`, {
       state: {
-        strategyTitle, // 전달할 전략 제목
-        strategyId: id, // 전달할 전략 ID
+        strategyTitle,
+        strategyId: id,
         traderId,
       },
     });
   };
-
-  // 옵셔널
-  // const handleInquiryPage = () => {
-  //   navigate(`${ROUTES.STRATEGY.INQUIRIES}`, {
-  //     state: {
-  //       strategyTitle: strategy?.strategyTitle, // 전달할 전략 제목
-  //       strategyId: strategy?.strategyId, // 전달할 전략 ID
-  //       traderId: strategy?.traderId,
-  //     },
-  //   });
-  // };
 
   const handleFollowingPage = () => {
     navigate(`${ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS}`);

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -20,7 +20,7 @@ interface StrategyHeaderProps {
 export const StrategyHeader = ({
   id,
   strategyTitle,
-  traderId = '71-88RZ_QQ65hMGknyWKLA', // 기본값으로 일단 설정하기!!!
+  traderId,
   onDelete,
   onApproval,
 }: StrategyHeaderProps) => {

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -11,11 +11,19 @@ import { UserRole } from '@/types/route';
 
 interface StrategyHeaderProps {
   id: number;
+  strategyTitle: string;
+  traderId: string;
   onDelete: (id: number) => void;
   onApproval: () => void;
 }
 
-export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps) => {
+export const StrategyHeader = ({
+  id,
+  strategyTitle,
+  traderId = '71-88RZ_QQ65hMGknyWKLA', // 기본값으로 일단 설정하기!!!
+  onDelete,
+  onApproval,
+}: StrategyHeaderProps) => {
   const navigate = useNavigate();
   const { user } = useAuthStore(); // store에서 user 정보 가져오기
 
@@ -23,9 +31,27 @@ export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps
     navigate(`${ROUTES.MYPAGE.TRADER.STRATEGIES.EDIT(id)}`);
   };
 
+  // 문의기페이지로 데이터 정보 넘김(요게 스테이트!!!)
   const handleInquiryPage = () => {
-    navigate(`${ROUTES.STRATEGY.INQUIRIES}`);
+    navigate(`${ROUTES.STRATEGY.INQUIRIES}`, {
+      state: {
+        strategyTitle, // 전달할 전략 제목
+        strategyId: id, // 전달할 전략 ID
+        traderId,
+      },
+    });
   };
+
+  // 옵셔널
+  // const handleInquiryPage = () => {
+  //   navigate(`${ROUTES.STRATEGY.INQUIRIES}`, {
+  //     state: {
+  //       strategyTitle: strategy?.strategyTitle, // 전달할 전략 제목
+  //       strategyId: strategy?.strategyId, // 전달할 전략 ID
+  //       traderId: strategy?.traderId,
+  //     },
+  //   });
+  // };
 
   const handleFollowingPage = () => {
     navigate(`${ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS}`);
@@ -39,7 +65,7 @@ export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps
         <GiCircle size={40} css={circleStyle} />
         <MdOutlineShare size={16} css={shareStyle} />
       </button>
-      {userRole === 'ROLE_TRADER' ? ( // 사용자 역할이 'ROLE_TRADER'(트레이더)인 경우
+      {userRole === 'ROLE_TRADER' ? ( // 트레이더 전용 버튼
         <div css={buttonAreaStyle}>
           <Button size='xs' variant='secondaryGray' width={90} onClick={() => onDelete(id)}>
             삭제
@@ -59,7 +85,6 @@ export const StrategyHeader = ({ id, onDelete, onApproval }: StrategyHeaderProps
           </Button>
         </div>
       ) : (
-        // 사용자 역할이 'INVESTOR'(투자자)인 경우 -> 기본값!!!
         <div css={buttonAreaStyle}>
           <Button
             size='sm'

--- a/src/pages/strategy/InquiryPage.tsx
+++ b/src/pages/strategy/InquiryPage.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useLocation } from 'react-router-dom';
 
 import PageHeader from '@/components/common/PageHeader';
 import InquiryCreateForm from '@/components/page/inquiry-create/InquiryCreateForm';
@@ -20,14 +21,24 @@ const desc = [
   },
 ];
 
-const InquiryPage = () => (
-  <>
-    <PageHeader title='문의하기' desc={desc} icon />
-    <div css={createContainerStyle}>
-      <InquiryCreateForm />
-    </div>
-  </>
-);
+const InquiryPage = () => {
+  const location = useLocation();
+  const { strategyTitle, strategyId, traderId } = location.state || {}; // 전달된 데이터 가져오기
+
+  return (
+    <>
+      <PageHeader title='문의하기' desc={desc} icon />
+      <div css={createContainerStyle}>
+        {/* 데이터를 InquiryCreateForm에 전달 */}
+        <InquiryCreateForm
+          strategyTitle={strategyTitle}
+          strategyId={strategyId}
+          traderId={traderId}
+        />
+      </div>
+    </>
+  );
+};
 
 const createContainerStyle = css`
   width: ${theme.layout.width.content};

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -145,6 +145,8 @@ const StrategyDetailPage = () => {
           <div key={strategy?.strategyId}>
             <StrategyHeader
               id={strategy?.strategyId}
+              strategyTitle={strategy?.strategyTitle || ''} // 전략명
+              traderId={strategy?.traderId || ''} // 트레이드ID
               onApproval={() => {
                 handleApproval();
               }}

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -145,8 +145,8 @@ const StrategyDetailPage = () => {
           <div key={strategy?.strategyId}>
             <StrategyHeader
               id={strategy?.strategyId}
-              strategyTitle={strategy?.strategyTitle || ''} // 전략명
-              traderId={strategy?.traderId || ''} // 트레이드ID
+              strategyTitle={strategy?.strategyTitle || ''}
+              traderId={strategy?.traderId || ''}
               onApproval={() => {
                 handleApproval();
               }}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

 전략상세페이지 데이터를 State로 문의등록페이지에 데이터 연결하기
 - 주석이 많습니다.! 나중에 지울게요
 - 트레이더ID는 고정값으로 일단 넣었습니다!

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/f51447ad-3a02-42b9-abd7-eb2c4f524105)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

전략 제목, ID 및 트레이더 ID의 전송을 허용하기 위해 상태를 사용하여 전략 세부 페이지 데이터를 문의 등록 페이지에 연결합니다. 이 데이터 흐름을 지원하기 위해 StrategyHeader 및 InquiryCreateForm 컴포넌트를 향상시킵니다.

새로운 기능:
- 상태를 사용하여 전략 세부 페이지 데이터를 문의 등록 페이지에 연결합니다.

향상된 기능:
- StrategyHeader 컴포넌트에 전략 제목과 트레이더 ID를 props로 추가합니다.
- InquiryPage에서 InquiryCreateForm 컴포넌트에 전략 데이터를 전달합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Connect strategy detail page data to the inquiry registration page using state, allowing the transfer of strategy title, ID, and trader ID. Enhance StrategyHeader and InquiryCreateForm components to support this data flow.

New Features:
- Connect strategy detail page data to the inquiry registration page using state.

Enhancements:
- Add strategy title and trader ID as props to StrategyHeader component.
- Pass strategy data to InquiryCreateForm component in InquiryPage.

</details>