### PR TITLE
[Feat] 전략상세 일간분석 수정, 삭제 API 반영(예외처리중, 머지X)

### DIFF
--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -1,6 +1,7 @@
 import { apiClient, createFormDataRequest } from './apiClient';
 import { API_ENDPOINTS } from './apiEndpoints';
 
+import { UserRole } from '@/types/route';
 import {
   FileUploadOptions,
   FileUploadResponse,
@@ -112,14 +113,19 @@ export const fetchPutDailyAnalysis = async (
 };
 
 //일간분석 삭제
-export const fetchDeleteDailyAnalysis = async (strategyId: number[], analysisId: number) => {
+export const fetchDeleteDailyAnalysis = async (
+  strategyId: number[],
+  analysisId: number,
+  role: UserRole
+) => {
+  const body = strategyId;
   try {
-    const req = await apiClient.delete(
+    const req = await apiClient.post(
       `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/daily-analyses/${analysisId}`,
+      body,
       {
         headers: {
-          'Content-Type': 'application/json',
-          Auth: 'admin',
+          Auth: role,
         },
       }
     );

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -5,6 +5,7 @@ import {
   FileUploadOptions,
   FileUploadResponse,
   InputDailyAnalysisProps,
+  DailyAnalysisProps,
 } from '@/types/strategyDetail';
 
 //전략 상세 기본 정보 조회
@@ -86,6 +87,30 @@ export const fetchPostDailyAnalysis = async (
 };
 
 //일간분석 수정
+export const fetchPutDailyAnalysis = async (
+  strategyId: number,
+  payload: DailyAnalysisProps,
+  authRole: 'admin' | 'trader',
+  dailyDataId: number
+) => {
+  const body = payload;
+  try {
+    const req = await apiClient.put(
+      `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/daily-data/${dailyDataId}`,
+      body,
+      {
+        headers: {
+          Auth: authRole,
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to fetch Put DailyAnalysis', error);
+    throw error;
+  }
+};
+
 //일간분석 삭제
 export const fetchDeleteDailyAnalysis = async (strategyId: number[], analysisId: number) => {
   try {
@@ -125,7 +150,7 @@ export const fetchMonthlyAnalysis = async (strategyId: number, page: number, pag
   }
 };
 
-//전략 상세 통계 조회 (MSW)
+//전략 상세 통계 조회
 export const fetchStatistics = async (strategyId: number) => {
   try {
     const res = await apiClient.get(`${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/statistics`, {

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -114,14 +114,14 @@ export const fetchPutDailyAnalysis = async (
 
 //일간분석 삭제
 export const fetchDeleteDailyAnalysis = async (
-  strategyId: number[],
-  analysisId: number,
-  role: UserRole
+  strategyId: number,
+  role: UserRole,
+  analysisIds: number[]
 ) => {
-  const body = strategyId;
+  const body = { dailyStatisticsId: analysisIds };
   try {
     const req = await apiClient.post(
-      `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/daily-analyses/${analysisId}`,
+      `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/daily-analyses/delete`,
       body,
       {
         headers: {

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -3,12 +3,11 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 import { BiPlus } from 'react-icons/bi';
 
-import InputTable, { InputTableProps } from './InputTable';
+import { InputTableProps } from './InputTable';
 import TableModal from './TableModal';
 
 import Button from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
-import useTableModalStore from '@/stores/tableModalStore';
 import theme from '@/styles/theme';
 
 export interface AnalysisAttribuesProps {
@@ -33,6 +32,7 @@ export interface AnalysisProps {
   analysis?: NormalizedAnalysProps[];
   selectedItems?: number[];
   onUpload?: () => void;
+  onEdit?: (rowId: number, data: InputTableProps) => void;
   onSelectChange?: (selectIdx: number[]) => void;
 }
 
@@ -42,11 +42,10 @@ const AnalysisTable = ({
   mode,
   selectedItems,
   onUpload,
+  onEdit,
   onSelectChange,
 }: AnalysisProps) => {
   const [selectAll, setSelectAll] = useState(false);
-  const [tableData, setTableData] = useState<InputTableProps[]>([]);
-  const { openTableModal } = useTableModalStore();
 
   const handleAllChecked = () => {
     const newSelectAll = !selectAll;
@@ -62,27 +61,6 @@ const AnalysisTable = ({
       : [...(selectedItems ?? []), idx];
 
     onSelectChange?.(updatedSelected);
-  };
-
-  const handleInputChange = (updatedData: InputTableProps[]) => {
-    setTableData(updatedData);
-  };
-
-  const handleUpdateData = (data: InputTableProps, idx: number) => {
-    const updatedTableData = [...tableData];
-    updatedTableData[idx] = { ...updatedTableData[idx], ...data };
-    setTableData(updatedTableData);
-  };
-
-  const handleUpdateModal = (data: InputTableProps, idx: number) => {
-    openTableModal({
-      type: 'update',
-      title: '일간분석 데이터 수정',
-      data: <InputTable data={[data]} onChange={handleInputChange} />,
-      onAction: () => {
-        handleUpdateData(data, idx);
-      },
-    });
   };
 
   const getColorValue = (item: number) => {
@@ -146,14 +124,11 @@ const AnalysisTable = ({
                       size='xs'
                       width={65}
                       onClick={() =>
-                        handleUpdateModal(
-                          {
-                            date: values.date,
-                            depWdPrice: values.dep_wd_price,
-                            dailyProfitLoss: values.profit_loss,
-                          },
-                          values.dataId
-                        )
+                        onEdit?.(values.dataId, {
+                          date: values.date,
+                          depWdPrice: values.dep_wd_price,
+                          dailyProfitLoss: values.profit_loss,
+                        })
                       }
                     >
                       수정

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { BiPlus } from 'react-icons/bi';
 
@@ -33,8 +31,10 @@ export interface AnalysisProps {
   strategyId?: number;
   analysis?: NormalizedAnalysProps[];
   selectedItems?: number[];
+  selectAll?: boolean;
   onUpload?: () => void;
   onEdit?: (rowId: number, data: InputTableProps) => void;
+  onSelectAll?: (checked: boolean) => void;
   onSelectChange?: (selectIdx: number[]) => void;
 }
 
@@ -42,21 +42,13 @@ const AnalysisTable = ({
   attributes,
   analysis,
   mode,
+  selectAll,
   selectedItems,
   onUpload,
   onEdit,
+  onSelectAll,
   onSelectChange,
 }: AnalysisProps) => {
-  const [selectAll, setSelectAll] = useState(false);
-
-  const handleAllChecked = () => {
-    const newSelectAll = !selectAll;
-    setSelectAll(newSelectAll);
-    mode === 'write' &&
-      analysis &&
-      onSelectChange?.(newSelectAll ? analysis.map((item) => item.dataId) : []);
-  };
-
   const handleSelected = (idx: number) => {
     const updatedSelected = (selectedItems ?? []).includes(idx)
       ? (selectedItems ?? []).filter((item) => item !== idx)
@@ -79,7 +71,10 @@ const AnalysisTable = ({
           <tr css={tableRowStyle}>
             {mode === 'write' && (
               <th css={tableHeadStyle}>
-                <Checkbox checked={selectAll} onChange={handleAllChecked} />
+                <Checkbox
+                  checked={selectAll ?? false}
+                  onChange={(checked) => mode === 'write' && analysis && onSelectAll?.(checked)}
+                />
               </th>
             )}
             {attributes.map((item, idx) => (

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -9,6 +9,7 @@ import TableModal from './TableModal';
 import Button from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
 import theme from '@/styles/theme';
+import { UserRole } from '@/types/route';
 
 export interface AnalysisAttribuesProps {
   title: string;
@@ -28,6 +29,7 @@ interface NormalizedAnalysProps {
 export interface AnalysisProps {
   mode: 'write' | 'read';
   attributes: AnalysisAttribuesProps[];
+  role?: UserRole;
   strategyId?: number;
   analysis?: NormalizedAnalysProps[];
   selectedItems?: number[];

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -133,7 +133,16 @@ const DailyAnalysis = ({ strategyId, attributes }: AnalysisProps) => {
     setSelectedData(selectedIdx);
   };
 
+  //TODO: selected된 아이디들의 일간분석 날짜를 가져와서 오름차순 한 날짜를 바디로 변환해서 삭제 api로 쏴야함
   const handleDelete = () => {
+    const selectedDailyAnalysis = dailyAnalysis
+      .filter((item: AnalysisDataProps) => selectedData.includes(item.dailyStrategicStatisticsId))
+      .sort(
+        (a: AnalysisDataProps, b: AnalysisDataProps) =>
+          new Date(a.inputDate).getHours() - new Date(b.inputDate).getHours()
+      );
+
+    console.log(selectedDailyAnalysis);
     openModal({
       type: 'warning',
       title: '일간분석 삭제',

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -153,10 +153,7 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
     if (!role || !strategyId) return;
     const selectedDailyAnalysis = dailyAnalysis
       .filter((item: AnalysisDataProps) => selectedData.includes(item.dailyStrategicStatisticsId))
-      .sort(
-        (a: AnalysisDataProps, b: AnalysisDataProps) =>
-          new Date(a.inputDate).getHours() - new Date(b.inputDate).getHours()
-      )
+      .sort((a: AnalysisDataProps, b: AnalysisDataProps) => a.inputDate.localeCompare(b.inputDate))
       .map((sortData: AnalysisDataProps) => sortData.dailyStrategicStatisticsId);
 
     if (selectedDailyAnalysis.length > 0) {

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { BiPlus } from 'react-icons/bi';
@@ -24,6 +24,7 @@ import { DailyAnalysisProps, AnalysisDataProps } from '@/types/strategyDetail';
 
 const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
   const [selectedData, setSelectedData] = useState<number[]>([]);
+  const [selectAll, setSelectAll] = useState(false);
   const { pagination, setPage } = usePagination(1, 5);
   const { showToast, type, message, hideToast, isToastVisible } = useToastStore();
   const { openModal } = useModalStore();
@@ -138,6 +139,16 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
     setSelectedData(selectedIdx);
   };
 
+  const handleAllChecked = () => {
+    const newSelectAll = !selectAll;
+    setSelectAll(newSelectAll);
+    handleSelectChange(
+      newSelectAll
+        ? dailyAnalysis.map((item: AnalysisDataProps) => item.dailyStrategicStatisticsId)
+        : []
+    );
+  };
+
   const handleDelete = () => {
     if (!role || !strategyId) return;
     const selectedDailyAnalysis = dailyAnalysis
@@ -166,6 +177,11 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
       });
     }
   };
+
+  useEffect(() => {
+    setSelectedData([]);
+    setSelectAll(false);
+  }, [pagination.currentPage]);
 
   if (isLoading) {
     return <div>로딩중...</div>;
@@ -201,9 +217,11 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
         analysis={normalizedData}
         mode={'write'}
         role={role}
+        selectAll={selectAll}
         selectedItems={selectedData}
         onUpload={handleOpenModal}
         onSelectChange={handleSelectChange}
+        onSelectAll={handleAllChecked}
         onEdit={handleUpdateModal}
       />
       <div css={PaginationArea}>

--- a/src/hooks/mutations/useDailyAnalysis.ts
+++ b/src/hooks/mutations/useDailyAnalysis.ts
@@ -1,6 +1,11 @@
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 
-import { fetchPostDailyAnalysis, fetchPutDailyAnalysis } from '@/api/strategyDetail';
+import {
+  fetchDeleteDailyAnalysis,
+  fetchPostDailyAnalysis,
+  fetchPutDailyAnalysis,
+} from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
 import { DailyAnalysisProps } from '@/types/strategyDetail';
 
 export const usePostDailyAnalysis = () => {
@@ -39,6 +44,25 @@ export const usePutDailyAnalysis = () => {
       dailyDataId: number;
     }) => fetchPutDailyAnalysis(strategyId, payload, authRole, dailyDataId),
     onError: (error) => error.message,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dailyAnalysis'] });
+    },
+  });
+};
+
+export const useDeleteAnalysis = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      role,
+      analysisIds,
+    }: {
+      strategyId: number;
+      role: UserRole;
+      analysisIds: number[];
+    }) => fetchDeleteDailyAnalysis(strategyId, role, analysisIds),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dailyAnalysis'] });
     },

--- a/src/hooks/mutations/useDailyAnalysis.ts
+++ b/src/hooks/mutations/useDailyAnalysis.ts
@@ -1,6 +1,6 @@
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 
-import { fetchPostDailyAnalysis } from '@/api/strategyDetail';
+import { fetchPostDailyAnalysis, fetchPutDailyAnalysis } from '@/api/strategyDetail';
 import { DailyAnalysisProps } from '@/types/strategyDetail';
 
 export const usePostDailyAnalysis = () => {
@@ -16,6 +16,28 @@ export const usePostDailyAnalysis = () => {
       payload: DailyAnalysisProps[];
       authRole: 'admin' | 'trader';
     }) => fetchPostDailyAnalysis(strategyId, { payload }, authRole),
+    onError: (error) => error.message,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dailyAnalysis'] });
+    },
+  });
+};
+
+export const usePutDailyAnalysis = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      payload,
+      authRole,
+      dailyDataId,
+    }: {
+      strategyId: number;
+      payload: DailyAnalysisProps;
+      authRole: 'admin' | 'trader';
+      dailyDataId: number;
+    }) => fetchPutDailyAnalysis(strategyId, payload, authRole, dailyDataId),
     onError: (error) => error.message,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dailyAnalysis'] });

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -22,6 +22,7 @@ import { monthlyAttribues, dailyAttribues, statisticsMapping } from '@/constants
 import useStrategyDetailDelete from '@/hooks/mutations/useStrategyDetailDelete';
 import useFetchStrategyDetail from '@/hooks/queries/useFetchStrategyDetail';
 import useStatistics from '@/hooks/queries/useStatistics';
+import { useAuthStore } from '@/stores/authStore';
 import useModalStore from '@/stores/modalStore';
 import theme from '@/styles/theme';
 import { StatisticsProps } from '@/types/strategyDetail';
@@ -57,6 +58,7 @@ const rejectReasonData = {
 };
 
 const StrategyDetailPage = () => {
+  const { user } = useAuthStore();
   const { strategyId } = useParams();
   const navigate = useNavigate();
   const { strategy } = useFetchStrategyDetail(strategyId || '');
@@ -97,7 +99,12 @@ const StrategyDetailPage = () => {
     {
       title: '일간분석',
       component: (
-        <DailyAnalysis attributes={dailyAttribues} strategyId={Number(strategyId)} mode='write' />
+        <DailyAnalysis
+          attributes={dailyAttribues}
+          strategyId={Number(strategyId)}
+          mode='write'
+          role={user?.role}
+        />
       ),
     },
     {
@@ -107,6 +114,7 @@ const StrategyDetailPage = () => {
           attributes={monthlyAttribues}
           strategyId={Number(strategyId)}
           mode='read'
+          role={user?.role}
         />
       ),
     },

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import Loader from '@/components/common/Loading';
 import Modal from '@/components/common/Modal';
 import ChartSection from '@/components/page/strategy-detail/chart/ChartSection';
 import FileDownSection from '@/components/page/strategy-detail/FileDownSection';
@@ -64,7 +65,7 @@ const StrategyDetailPage = () => {
   const { openModal } = useModalStore();
 
   if (!strategy) {
-    return <div>로딩중....</div>;
+    return <Loader />;
   }
 
   const statisticsTableData = (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

전략 상세 페이지 일간분석 조회, 등록, 수정, 삭제 API 모두 반영했습니다.
서버에서 모든 데이터를 한번에 불러오는게 아니라 페이지네이션 클릭 시 currentPage에 해당하는 값들만 잘라서 보내주기 때문에
네이버 메일 삭제되는 로직 참고해서 테이블 상단의 전체삭제 버튼 클릭 시 해당 페이지의 항목들이 전체 선택되도록 구현해두었습니다.
1페이지에서 항목 선택 후 2 페이지로 넘어가면 1페이지에 선택해두었던 체크박스 상태는 초기화되도록 구현했습니다.  (이것도 네이버메일 참고)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![Nov-30-2024 00-40-44](https://github.com/user-attachments/assets/4683a888-f403-4d17-911c-414b400ceca1)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
