### PR TITLE
[Feat] 전략 상세 일간분석 예외처리 및 월간분석 조회 API 반영

### DIFF
--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -64,7 +64,6 @@ const AnalysisTable = ({
     return null;
   };
 
-  console.log(analysis);
   return (
     <div css={tableStyle}>
       <table css={tableVars}>
@@ -137,25 +136,31 @@ const AnalysisTable = ({
             ))
           ) : (
             <tr>
-              <td colSpan={attributes.length + 1} css={noDataStyle}>
-                내용을 추가해주세요.
-                <div css={addArea}>
-                  <Button
-                    variant='secondary'
-                    size='xs'
-                    width={116}
-                    css={buttonStyle}
-                    onClick={onUpload}
-                  >
-                    <BiPlus size={16} />
-                    직접입력
-                  </Button>
-                  <Button variant='accent' size='xs' width={116} css={buttonStyle}>
-                    <BiPlus size={16} />
-                    엑셀추가
-                  </Button>
-                </div>
-              </td>
+              {mode === 'write' ? (
+                <td colSpan={attributes.length + 1} css={noDataStyle}>
+                  일간분석 데이터를 추가해주세요.
+                  <div css={addArea}>
+                    <Button
+                      variant='secondary'
+                      size='xs'
+                      width={116}
+                      css={buttonStyle}
+                      onClick={onUpload}
+                    >
+                      <BiPlus size={16} />
+                      직접입력
+                    </Button>
+                    <Button variant='accent' size='xs' width={116} css={buttonStyle}>
+                      <BiPlus size={16} />
+                      엑셀추가
+                    </Button>
+                  </div>
+                </td>
+              ) : (
+                <td colSpan={attributes.length + 1} css={noDataStyle}>
+                  데이터가 없습니다. 일간분석 데이터를 입력하세요.
+                </td>
+              )}
             </tr>
           )}
         </tbody>
@@ -175,7 +180,7 @@ const tableStyle = css`
   .checkbox {
     cursor: pointer;
   }
-  min-height: 430px;
+  max-height: 430px;
 `;
 
 const tableVars = css`

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -64,6 +64,7 @@ const AnalysisTable = ({
     return null;
   };
 
+  console.log(analysis);
   return (
     <div css={tableStyle}>
       <table css={tableVars}>

--- a/src/components/page/strategy-detail/table/InputTable.tsx
+++ b/src/components/page/strategy-detail/table/InputTable.tsx
@@ -2,13 +2,12 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 
-import Input from '@/components/common/Input';
 import theme from '@/styles/theme';
 
 export interface InputTableProps {
   date: string;
-  depWdPrice: number;
-  dailyProfitLoss: number;
+  depWdPrice: number | string;
+  dailyProfitLoss: number | string;
 }
 
 export interface InputAnalysisProps {
@@ -21,8 +20,22 @@ const attributes = ['일자', '입출금', '일손익'];
 const InputTable = ({ data, onChange }: InputAnalysisProps) => {
   const [inputData, setInputData] = useState<InputTableProps[]>(data);
 
-  const handleInputChange = (idx: number, field: keyof InputTableProps, value: string) => {
-    const updatedData = inputData.map((row, i) => (i === idx ? { ...row, [field]: value } : row));
+  const handleInputChange = (
+    idx: number,
+    field: keyof InputTableProps,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (e.target.value.length > 10) {
+      return;
+    }
+    let passValue = e.target.value;
+    if (field !== 'date') {
+      const numericValue = e.target.value.replace(/[^-+0-9]/g, '');
+      passValue = numericValue.replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/g, '');
+    }
+    const updatedData = inputData.map((row, i) =>
+      i === idx ? { ...row, [field]: passValue } : row
+    );
     setInputData(updatedData);
     onChange(updatedData);
   };
@@ -43,28 +56,28 @@ const InputTable = ({ data, onChange }: InputAnalysisProps) => {
           {inputData.map((row, idx) => (
             <tr key={idx} css={tableRowStyle}>
               <td css={tableCellStyle}>
-                <Input
+                <input
                   type='date'
                   value={row.date}
-                  onChange={(e) => handleInputChange(idx, 'date', e.target.value)}
+                  onChange={(e) => handleInputChange(idx, 'date', e)}
                   css={inputStyle}
                 />
               </td>
               <td css={tableCellStyle}>
-                <Input
-                  type='number'
+                <input
+                  type='text'
                   value={row.depWdPrice}
                   placeholder='예)123,456,789'
-                  onChange={(e) => handleInputChange(idx, 'depWdPrice', e.target.value)}
+                  onChange={(e) => handleInputChange(idx, 'depWdPrice', e)}
                   css={inputStyle}
                 />
               </td>
               <td css={tableCellStyle}>
-                <Input
-                  type='number'
+                <input
+                  type='text'
                   value={row.dailyProfitLoss}
                   placeholder='예)+123,456'
-                  onChange={(e) => handleInputChange(idx, 'dailyProfitLoss', e.target.value)}
+                  onChange={(e) => handleInputChange(idx, 'dailyProfitLoss', e)}
                   css={inputStyle}
                 />
               </td>
@@ -124,6 +137,30 @@ const tableCellStyle = css`
 const inputStyle = css`
   width: 100%;
   border-radius: 4px;
+  position: relative;
+  height: ${theme.input.height.md};
+  padding: ${theme.input.padding.md};
+  font-size: ${theme.input.fontSize.md};
+  background-color: ${theme.colors.main.white};
+  border: 1px solid ${theme.colors.gray[300]};
+  outline: none;
+  font-size: ${theme.typography.fontSizes.body};
+  color: ${theme.colors.main.black};
+  background-color: ${theme.colors.main.white};
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: ${theme.colors.main.primary};
+  }
+
+  &:focus {
+    border-color: ${theme.colors.main.primary};
+  }
+
+  &::placeholder {
+    color: ${theme.colors.gray[700] + '4a'};
+    font-weight: ${theme.typography.fontWeight.regular};
+  }
 
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -56,8 +56,8 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
     let modalData: InputTableProps[] = [];
     const initalData: InputTableProps[] = Array.from({ length: 5 }, () => ({
       date: '',
-      depWdPrice: 0,
-      dailyProfitLoss: 0,
+      depWdPrice: '',
+      dailyProfitLoss: '',
     }));
 
     openTableModal({
@@ -116,7 +116,7 @@ const DailyAnalysis = ({ strategyId, attributes, role }: AnalysisProps) => {
           onChange={(newData) =>
             (updatedData = {
               date: newData[0].date,
-              dailyProfitLoss: newData[0].dailyProfitLoss,
+              dailyProfitLoss: Number(newData[0].dailyProfitLoss),
               depWdPrice: Number(newData[0].depWdPrice),
             })
           }

--- a/src/hooks/queries/useFetchMonthlyAnalysis.ts
+++ b/src/hooks/queries/useFetchMonthlyAnalysis.ts
@@ -1,0 +1,37 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { fetchMonthlyAnalysis } from '@/api/strategyDetail';
+
+const useFetchMonthlyAnalysis = (strategyId: number, page: number, pageSize: number) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['monthlyAnalysis', strategyId, page, pageSize],
+    queryFn: async () => {
+      const res = await fetchMonthlyAnalysis(strategyId, page, pageSize);
+      if (!strategyId) {
+        throw new Error('Invalid monthlyAnalysis');
+      }
+      return {
+        analysis: res.data,
+        pagination: {
+          currentPage: res.currentPage,
+          totalPages: res.totalPages,
+          pageSize: res.pageSize,
+          totalElements: res.totalElements,
+        },
+        time: res.timestamp,
+      };
+    },
+    enabled: !!strategyId,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    monthlyAnalysis: data?.analysis,
+    currentPage: data?.pagination.currentPage,
+    totalPages: data?.pagination.totalPages,
+    pageSize: data?.pagination.pageSize,
+    isLoading,
+  };
+};
+
+export default useFetchMonthlyAnalysis;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -162,9 +162,9 @@ const StrategyDetailPage = () => {
             <IconTagSection imgs={imgTest} />
             <StrategyTitleSection
               title={strategy?.strategyTitle}
-              traderId={strategy?.traderId}
-              traderName={strategy?.traderName}
-              imgUrl={strategy?.traderImage}
+              traderId={strategy?.memberId}
+              traderName={strategy?.nickname}
+              imgUrl={strategy?.profilePath}
               date={formatDate(strategy?.writedAt || '', 'withDayTime')}
               followers={strategy?.followersCount}
               minimumInvestment={strategy?.minInvestmentAmount}

--- a/src/types/strategyDetail.ts
+++ b/src/types/strategyDetail.ts
@@ -21,8 +21,8 @@ export interface StrategyDetailProps {
 
 export interface DailyAnalysisProps {
   date: string;
-  dailyProfitLoss: number;
-  depWdPrice: number;
+  dailyProfitLoss: number | string;
+  depWdPrice: number | string;
 }
 
 export interface InputDailyAnalysisProps {

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -15,3 +15,10 @@ export const formatValue = (key: string, value: string | number) => {
     return value;
   }
 };
+
+// +-숫자 형식인지 확인
+export const isValidInputNumber = (value: string | number): boolean => {
+  const sanitizedValue = String(value).trim();
+  if (/[^-+0-9]/g.test(sanitizedValue)) return false;
+  return !isNaN(Number(sanitizedValue));
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

일간분석 테이블에 이미 등록된 날짜로 다시 등록하려고 하면 토스트 알림을 띄웁니다.
일간분석 테이블 입력란에 숫자가 아닌 입력은 할 수 없도록 막았습니다.
일간분석 테이블 내 한 필드에서 날짜, 입출금, 일손익 3가지 모두를 입력하지 않고 확인을 누를 경우 경고 토스트 알림을 띄웁니다.
월간분석 조회 API 반영
예외처리 할 부분이 분명 더 .. 생길텐데 이후 차트 작업 및 엑셀업로드 실계좌 이미지 관련 작업 진행하면서 그 부분들은 같이 진행하도록 하겠습니다

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

입력 유효성 검사 및 오류 처리를 통해 일일 분석 구성 요소를 향상시키고, 전략 세부 정보에 대한 월간 분석 검색 API를 구현합니다.

새로운 기능:
- 전략 세부 정보에 대한 월간 분석 검색 API 구현.

향상된 기능:
- 비숫자 입력을 방지하고 필수 필드가 채워지도록 하기 위해 일일 분석에 입력 유효성 검사 추가.
- 중복 날짜 및 누락된 필수 필드에 대한 토스트 알림을 표시하여 일일 분석의 오류 처리 개선.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the daily analysis component with input validation and error handling, and implement the monthly analysis retrieval API for strategy details.

New Features:
- Implement monthly analysis retrieval API for strategy details.

Enhancements:
- Add input validation for daily analysis to prevent non-numeric entries and ensure required fields are filled.
- Improve error handling in daily analysis by showing toast notifications for duplicate dates and missing required fields.

</details>