### PR TITLE
[Feat] 비밀번호 재설정 페이지 구현 (+api연결) #269

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -13,7 +13,7 @@ export const API_ENDPOINTS = {
     FIND: {
       EMAIL: '/api/members/find-email', // 전화번호로 이메일 찾기
       PASSWORD: '/api/members/find/password', // 비밀번호 찾기
-      PASSWORD_RESET: '/api/members/find/password/reset', // 비밀번호 재설정
+      PASSWORD_RESET: '/api/members/reset-password', // 비밀번호 재설정
     },
     EMAIL: {
       REQUEST_VERIFICATION_FOR_SIGNUP: '/api/members/check-email', // 회원가입 시, 이메일 확인 + 이메일 인증 코드 요청

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -343,3 +343,41 @@ export const adminSignout = async (): Promise<AdminSignoutResponse> => {
     throw error;
   }
 };
+
+// 비밀번호 재설정 API
+interface ResetPasswordResponse {
+  status: 'success' | 'error';
+  message: string;
+}
+
+export const resetPassword = async ({
+  email,
+  newPassword,
+  confirmPassword,
+}: {
+  email: string;
+  newPassword: string;
+  confirmPassword: string;
+}): Promise<ResetPasswordResponse> => {
+  try {
+    const response = await apiClient.patch<ResetPasswordResponse>(
+      API_ENDPOINTS.AUTH.FIND.PASSWORD_RESET,
+      { email, newPassword, confirmPassword }
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      // 비밀번호 불일치
+      if (error.response?.data?.error === 'PASSWORD_MISMATCH') {
+        throw new Error('비밀번호가 서로 일치하지 않습니다.');
+      }
+      // 비밀번호 형식 오류
+      if (error.response?.data?.error === 'INVALID_PASSWORD_FORMAT') {
+        throw new Error('비밀번호는 숫자, 문자, 특수문자를 포함한 8자리 이상 입력해야 합니다.');
+      }
+      // 기타 에러
+      throw new Error(error.response?.data?.message || '비밀번호 재설정에 실패했습니다.');
+    }
+    throw error;
+  }
+};

--- a/src/hooks/mutations/useResetPasswordMutation.ts
+++ b/src/hooks/mutations/useResetPasswordMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { resetPassword } from '@/api/auth';
+
+export const useResetPasswordMutation = () =>
+  useMutation({
+    mutationFn: resetPassword,
+    onError: (error) => {
+      // 에러 처리
+      console.error('비밀번호 리셋 실패: ', error);
+    },
+  });

--- a/src/pages/auth/find/FindPasswordPage.tsx
+++ b/src/pages/auth/find/FindPasswordPage.tsx
@@ -96,7 +96,7 @@ const FindPasswordPage = () => {
       {
         onSuccess: (response) => {
           if (response.status === 'success') {
-            navigate(ROUTES.AUTH.FIND.PASSWORD_RESET, { replace: true });
+            navigate(ROUTES.AUTH.FIND.PASSWORD_RESET, { replace: true, state: { email } });
           } else {
             setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
           }

--- a/src/pages/auth/find/ResetPasswordPage.tsx
+++ b/src/pages/auth/find/ResetPasswordPage.tsx
@@ -1,46 +1,136 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import tickImage from '@/assets/images/tick.svg';
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import { ROUTES } from '@/constants/routes';
+import { useResetPasswordMutation } from '@/hooks/mutations/useResetPasswordMutation';
 import theme from '@/styles/theme';
-const ResetPasswordPage = () => (
-  <div css={containerStyle}>
-    <h3 css={pageHeadingStyle}>비밀번호 재설정</h3>
-    <p css={infoStyle}>
-      <img src={tickImage} alt='tick' />
-      <span>영문, 숫자를 포함한 8자 이상의 비밀번호를 입력해주세요</span>
-    </p>
-    <form css={formStyle}>
-      <Input
-        type='password'
-        inputSize='lg'
-        required
-        name='newpassword'
-        placeholder='새 비밀번호 등록'
-        css={inputStyle}
-      />
-      <Input
-        type='password'
-        inputSize='lg'
-        required
-        name='newpassword-confirm'
-        placeholder='새 비밀번호 확인'
-      />
-      <Button type='submit' width={400} disabled>
-        완료
-      </Button>
-    </form>
-    <ul css={findEmailLinkStyle}>
-      <li>이메일이 기억나지 않나요?</li>
-      <li>
-        <Link to={ROUTES.AUTH.FIND.EMAIL}>이메일 찾기</Link>
-      </li>
-    </ul>
-  </div>
-);
+import { isValidPassword } from '@/utils/validation';
+const ResetPasswordPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const email = location.state?.email;
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const { mutate: resetPassword } = useResetPasswordMutation();
+
+  // 비밀번호 유효성 검사
+  const validatePassword = (newPassword: string) => {
+    const { isValid, message } = isValidPassword(newPassword);
+    if (!isValid) {
+      setErrorMessage(message);
+    }
+    return isValid;
+  };
+
+  // 비밀번호 일치 여부 검사
+  const validatePasswordMatch = () => {
+    if (newPassword !== confirmPassword) {
+      setErrorMessage('비밀번호가 일치하지 않습니다.');
+      return false;
+    }
+    return true;
+  };
+
+  // 폼 제출 처리
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // 기존 에러메시지 초기화
+    setErrorMessage('');
+
+    // 입력값이 없는 경우 처리
+    if (!newPassword) {
+      setErrorMessage('비밀번호를 입력해주세요.');
+      return;
+    }
+    if (!confirmPassword) {
+      setErrorMessage('비밀번호를 확인해주세요.');
+      return;
+    }
+
+    // 유효성 검사는 제출 시에만 진행
+    const isPasswordValid = validatePassword(newPassword);
+    if (!isPasswordValid) {
+      return;
+    }
+    const isPasswordMatch = validatePasswordMatch();
+    if (!isPasswordMatch) {
+      return;
+    }
+
+    const requestBody = { email, newPassword, confirmPassword };
+    console.log('Request body:', requestBody); // 요청 바디 확인
+
+    resetPassword(
+      { email, newPassword, confirmPassword },
+      {
+        onSuccess: () => {
+          navigate(ROUTES.AUTH.FIND.PASSWORD_RESET_SUCCESS);
+        },
+      }
+    );
+  };
+
+  return (
+    <div css={containerStyle}>
+      <h3 css={pageHeadingStyle}>비밀번호 재설정</h3>
+      <p css={infoStyle}>
+        <img src={tickImage} alt='tick' />
+        <span>영문, 숫자를 포함한 8자 이상의 비밀번호를 입력해주세요</span>
+      </p>
+      <form css={formStyle} onSubmit={handleSubmit}>
+        <Input
+          type='password'
+          inputSize='lg'
+          required
+          value={newPassword}
+          name='newPassword'
+          placeholder='새 비밀번호 등록'
+          css={inputStyle}
+          onChange={(e) => {
+            setNewPassword(e.target.value); // 새 비밀번호 입력값 변경
+            if (e.target.value === '') {
+              setErrorMessage(''); // 입력값이 없는 경우 에러메시지 초기화
+            }
+          }}
+          status={errorMessage ? 'error' : 'default'}
+        />
+        <Input
+          type='password'
+          inputSize='lg'
+          required
+          value={confirmPassword}
+          name='conformPassword'
+          placeholder='새 비밀번호 확인'
+          onChange={(e) => {
+            setConfirmPassword(e.target.value); // 새 비밀번호 확인 입력값 변경
+            if (e.target.value === '') {
+              setErrorMessage(''); // 입력값이 없는 경우 에러메시지 초기화
+            }
+          }}
+          status={errorMessage ? 'error' : 'default'}
+        />
+        {errorMessage && <p css={messageStyle}>{errorMessage}</p>}
+        <Button type='submit' width={400} disabled={!newPassword || !confirmPassword}>
+          완료
+        </Button>
+      </form>
+      <ul css={findEmailLinkStyle}>
+        <li>이메일이 기억나지 않나요?</li>
+        <li>
+          <Link to={ROUTES.AUTH.FIND.EMAIL}>이메일 찾기</Link>
+        </li>
+      </ul>
+    </div>
+  );
+};
 
 const containerStyle = css`
   display: flex;
@@ -117,5 +207,12 @@ const findEmailLinkStyle = css`
       display: none;
     }
   }
+`;
+const messageStyle = css`
+  margin-top: 16px;
+  text-align: center;
+  color: ${theme.colors.main.alert};
+  font-size: ${theme.typography.fontSizes.caption};
+  line-height: ${theme.typography.lineHeights.sm};
 `;
 export default ResetPasswordPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/644ae99c-b0be-4bba-97cb-ca7a938c5686



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

비밀번호 재설정 API와 통합된 양식 검증 기능을 갖춘 비밀번호 재설정 페이지를 구현합니다. 비밀번호 검증 및 오류 처리를 추가하여 사용자 피드백을 향상시킵니다.

새로운 기능:
- 양식 검증 및 API 통합을 갖춘 비밀번호 재설정 페이지 구현.

개선 사항:
- 비밀번호 재설정 시 사용자 피드백을 개선하기 위해 비밀번호 검증 및 오류 처리 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a password reset page with form validation and integrate it with the reset password API. Enhance user feedback by adding password validation and error handling.

New Features:
- Implement a password reset page with form validation and API integration.

Enhancements:
- Add password validation and error handling to improve user feedback during password reset.

</details>