### PR TITLE
[feat] 메인페이지 트레이더,전략 수 조회하기 api 연결

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -32,8 +32,9 @@ export const API_ENDPOINTS = {
     CREATE: '/api/strategies', // 전략 등록
     REGISTRATION_FORM: '/api/strategies/registration-form', // 전략 등록 옵션 조회
     UPDATE_FORM: '/api/strategies/update-form', // 전략 수정 조회
+    TRADER_STATS: '/api/strategies/strategy-trader-count', //트레이더 통계조회 (트레이더 수, 전략 수)
   },
-  INQUIRY: '/api/consultations', // 나의 문의
+  INQUIRY: '/api/consultations', // 나의 문의 , 문의 등록
   FILES: {
     PROFILE_URL: (memberId: string) => `/api/files/profile/${memberId}`, // 프로필 이미지 URL
     PROPOSAL: '/api/files/proposal', // 제안서 파일 업로드

--- a/src/api/traderStats.ts
+++ b/src/api/traderStats.ts
@@ -8,11 +8,7 @@ export interface TraderStatsParams {
 
 export const fetchTraderStats = async (): Promise<TraderStatsParams> => {
   try {
-    const res = await apiClient.get<TraderStatsParams>(API_ENDPOINTS.STRATEGY.TRADER_STATS, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    const res = await apiClient.get<TraderStatsParams>(API_ENDPOINTS.STRATEGY.TRADER_STATS);
 
     console.log('API Response:', res.data);
     return res.data;

--- a/src/api/traderStats.ts
+++ b/src/api/traderStats.ts
@@ -1,0 +1,23 @@
+import apiClient from '@/api/apiClient';
+import { API_ENDPOINTS } from '@/api/apiEndpoints';
+
+export interface TraderStatsParams {
+  traderCnt: number;
+  strategyCnt: number;
+}
+
+export const fetchTraderStats = async (): Promise<TraderStatsParams> => {
+  try {
+    const res = await apiClient.get<TraderStatsParams>(API_ENDPOINTS.STRATEGY.TRADER_STATS, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    console.log('API Response:', res.data);
+    return res.data;
+  } catch (error) {
+    console.error('Failed to fetch trader stats:', error);
+    throw error;
+  }
+};

--- a/src/components/page/home/TraderStats.tsx
+++ b/src/components/page/home/TraderStats.tsx
@@ -1,0 +1,74 @@
+import { css } from '@emotion/react';
+
+import TraderUserImage3 from '@/assets/images/ani_trader.png';
+import TraderUserImage1 from '@/assets/images/apt_trader.png';
+import TraderUserImage2 from '@/assets/images/nimo_trader.png';
+import theme from '@/styles/theme';
+
+interface TraderStatsProps {
+  traderCount: number;
+  strategyCount: number;
+}
+
+const TraderStats = ({ traderCount, strategyCount }: TraderStatsProps) => (
+  <div css={traderTotalStyle}>
+    <div css={statsImageContainerStyle}>
+      <img src={TraderUserImage1} alt='트레이더1' css={userImageStyle} />
+      <img src={TraderUserImage2} alt='트레이더2' css={userImageStyle} />
+      <img src={TraderUserImage3} alt='트레이더3' css={userImageStyle} />
+    </div>
+    <p css={statsTextStyle}>
+      <span css={highlightTextStyle}>+{traderCount}</span>
+      <span css={spacingTextStyle}>명의 트레이더가</span>
+      <span css={highlightTextStyle}>{strategyCount}</span>
+      <span css={spacingTextStyle}>개의 전략을 공유하고 있습니다</span>
+    </p>
+  </div>
+);
+
+const traderTotalStyle = css`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 16px;
+`;
+
+const statsImageContainerStyle = css`
+  display: flex;
+  position: relative;
+`;
+
+const userImageStyle = css`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid ${theme.colors.main.white};
+  position: relative;
+  margin-left: -12px;
+  &:first-of-type {
+    margin-left: 0;
+  }
+`;
+
+const statsTextStyle = css`
+  ${theme.textStyle.headings.h3}
+  color: ${theme.colors.gray[500]};
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+`;
+
+const highlightTextStyle = css`
+  ${theme.textStyle.headings.h2}
+  color: ${theme.colors.gray[900]};
+`;
+
+const spacingTextStyle = css`
+  color: ${theme.colors.gray[600]};
+  margin-right: 4px;
+`;
+
+export default TraderStats;

--- a/src/hooks/queries/useFetchStrategyTraderCount.ts
+++ b/src/hooks/queries/useFetchStrategyTraderCount.ts
@@ -13,6 +13,5 @@ export const useFetchStrategyTraderCount = () =>
       return res;
     },
     staleTime: 5 * 60 * 1000, // 5분 동안 데이터 재검증 생략
-    retry: 1, // 실패 시 한 번만 재시도
     refetchOnWindowFocus: false, // 창 포커스 시 리패치 비활성화
   });

--- a/src/hooks/queries/useFetchStrategyTraderCount.ts
+++ b/src/hooks/queries/useFetchStrategyTraderCount.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchTraderStats, TraderStatsParams } from '@/api/traderStats';
+
+export const useFetchStrategyTraderCount = () =>
+  useQuery<TraderStatsParams>({
+    queryKey: ['strategyTraderCount'],
+    queryFn: async () => {
+      const res = await fetchTraderStats();
+      if (!res.traderCnt || !res.strategyCnt) {
+        throw new Error('Invalid trader or strategy count data');
+      }
+      return res;
+    },
+    staleTime: 5 * 60 * 1000, // 5분 동안 데이터 재검증 생략
+    retry: 1, // 실패 시 한 번만 재시도
+    refetchOnWindowFocus: false, // 창 포커스 시 리패치 비활성화
+  });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,4 @@
-// import { useState, useEffect } from 'react';
-
 import { css } from '@emotion/react';
-// import axios from 'axios';
 import { MdKeyboardArrowRight, MdArrowForward } from 'react-icons/md';
 import { useNavigate, Link } from 'react-router-dom';
 
@@ -423,9 +420,9 @@ const userImageStyle = css`
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  border: 1px solid ${theme.colors.main.white}; /* 토탈공유 */
-  position: relative; /* 토탈공유 */
-  margin-left: -12px; /* 토탈공유 */
+  border: 1px solid ${theme.colors.main.white};
+  position: relative;
+  margin-left: -12px;
   &:first-of-type {
     margin-left: 0;
   }
@@ -471,8 +468,6 @@ const traderMainStyle = css`
 const leftSectionStyle = css`
   height: 520px;
 `;
-
-/* 트레이더 통계 조회 */
 
 const traderTextStyle = css`
   padding: 80px 0;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -29,7 +29,7 @@ const HomePage = () => {
   console.log('HomePage Data:', { traderCount, strategyCount });
 
   if (isLoading) {
-    <Loader />;
+    return <Loader />;
   }
   if (isError) {
     console.error('Error loading data...');

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+// import { useState, useEffect } from 'react';
 
 import { css } from '@emotion/react';
-import axios from 'axios';
+// import axios from 'axios';
 import { MdKeyboardArrowRight, MdArrowForward } from 'react-icons/md';
 import { useNavigate, Link } from 'react-router-dom';
 
@@ -13,33 +13,30 @@ import TraderUserImage2 from '@/assets/images/nimo_trader.png';
 import SMScoreGraphImage from '@/assets/images/SMScore_graph.png';
 import TraderMainImage from '@/assets/images/trader_main.png';
 import Button from '@/components/common/Button';
+import Loader from '@/components/common/Loading';
+import TraderStats from '@/components/page/home/TraderStats';
 import { ROUTES } from '@/constants/routes';
+import { useFetchStrategyTraderCount } from '@/hooks/queries/useFetchStrategyTraderCount';
 import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
 
 const HomePage = () => {
   const navigate = useNavigate();
   const { user } = useAuthStore(); // store에서 user 정보 가져오기
+  const { data, isLoading, isError } = useFetchStrategyTraderCount();
 
-  const [traderCount, setTraderCount] = useState('0'); // 기본값 설정
-  const [strategyCount, setStrategyCount] = useState('0'); // 기본값 설정
+  // 트레이더 및 전략 수 표시를 위한 데이터 처리
+  const traderCount = Number(data?.traderCnt ?? 0);
+  const strategyCount = Number(data?.strategyCnt ?? 0);
 
-  // role 확인용 로깅
-  console.log('Current user role:', user?.role);
+  console.log('HomePage Data:', { traderCount, strategyCount });
 
-  useEffect(() => {
-    const fetchTraderStats = async () => {
-      try {
-        const { data } = await axios.get('/api/trader-Strategy');
-        setTraderCount(data.traderCount || '0');
-        setStrategyCount(data.strategyCount || '0');
-      } catch (error) {
-        console.error('트레이더 통계 조회 실패:', error);
-      }
-    };
-
-    fetchTraderStats();
-  }, []);
+  if (isLoading) {
+    <Loader />;
+  }
+  if (isError) {
+    console.error('Error loading data...');
+  }
 
   const rankingData = [
     {
@@ -224,19 +221,8 @@ const HomePage = () => {
             </div>
           </div>
           {/* 통계 정보 */}
-          <div css={traderTotalStyle}>
-            <div css={statsImageContainerStyle}>
-              <img src={TraderUserImage1} alt='트레이더1' css={userImageStyle} />
-              <img src={TraderUserImage2} alt='트레이더2' css={userImageStyle} />
-              <img src={TraderUserImage3} alt='트레이더3' css={userImageStyle} />
-            </div>
-            <p css={statsTextStyle}>
-              <span css={highlightTextStyle}>+{traderCount}</span>
-              <span css={spacingTextStyle}>명의 트레이더가</span> {/* 간격 조정 */}
-              <span css={highlightTextStyle}>{strategyCount}</span>
-              <span css={spacingTextStyle}>개의 전략을 공유하고 있습니다</span> {/* 간격 조정 */}
-            </p>
-          </div>
+          <TraderStats traderCount={traderCount} strategyCount={strategyCount} />
+
           {/* 대표전략통합평균지표 */}
           <div css={metricsContainerStyle}>
             <img
@@ -486,38 +472,7 @@ const leftSectionStyle = css`
   height: 520px;
 `;
 
-const traderTotalStyle = css`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  margin-top: 16px;
-`;
-
-const statsImageContainerStyle = css`
-  display: flex;
-  position: relative;
-`;
-
-const statsTextStyle = css`
-  ${theme.textStyle.headings.h3}
-  color: ${theme.colors.gray[500]};
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-`;
-
-const highlightTextStyle = css`
-  ${theme.textStyle.headings.h2}
-  color: ${theme.colors.gray[900]};
-`;
-
-const spacingTextStyle = css`
-  color: ${theme.colors.gray[600]};
-  margin-right: 4px;
-`;
+/* 트레이더 통계 조회 */
 
 const traderTextStyle = css`
   padding: 80px 0;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

[feat] 메인페이지 트레이더,전략 수 조회하기  api 연결
- Auth는 로그인 안해도 보여지는 부분이라서 조건 안달았습니다.
- 트레이더수,전략 수 보여지는 부분은 스타일링도 같이 자식컴포넌트화 했습니다.
- 파일이름 통계, 라우터 생각해서 traderstats 와 strategytradercount 두가지 사용했습니다. 
- usestate,axios 연결한건 실제 api 구현하면서 삭제했습니다.

[질문]
- useFetchStrategyTraderCount.ts 를 보면 `retry: 1` 실패시 한번 재시도라고 했는데 다른 파일 보니까 캐시오염으로 재시도 안함으로 되어있더라구요, 그럼 저도 0으로 하는게 맞는 걸까요? 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/bcde0db7-398b-424e-b6cc-a5458e72a725)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

메인 페이지에 트레이더 및 전략 수를 가져와 표시하는 API를 통합하고, 코드 조직을 개선하기 위해 표시 로직을 별도의 컴포넌트로 리팩토링합니다.

새로운 기능:
- 메인 페이지에 트레이더 및 전략 수를 가져와 표시하는 API를 통합합니다.

개선 사항:
- 더 나은 모듈성을 위해 트레이더 및 전략 수 표시를 별도의 TraderStats 컴포넌트로 리팩토링합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate API to fetch and display trader and strategy counts on the main page, and refactor the display logic into a separate component for improved code organization.

New Features:
- Integrate API to fetch and display the number of traders and strategies on the main page.

Enhancements:
- Refactor the trader and strategy count display into a separate TraderStats component for better modularity.

</details>