### PR TITLE
[Feat] 실계좌 이미지 조회, 등록, 삭제 기능 구현

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -33,6 +33,7 @@ export const API_ENDPOINTS = {
     REGISTRATION_FORM: '/api/strategies/registration-form', // 전략 등록 옵션 조회
     UPDATE_FORM: '/api/strategies/update-form', // 전략 수정 조회
     TRADER_STATS: '/api/strategies/strategy-trader-count', //트레이더 통계조회 (트레이더 수, 전략 수)
+    UPLOAD_ACCOUNT_IMG: '/api/live-account-data', //실계좌 이미지 관리
   },
   INQUIRY: '/api/consultations', // 나의 문의 , 문의 등록
   FILES: {

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -301,7 +301,6 @@ export const fetchRealAccount = async (
 //실계좌 이미지 업로드
 export const fetchUploadRealAccount = async (
   strategyId: number,
-  displayName: string,
   fileItem: File,
   authRole: UserRole
 ) => {
@@ -311,9 +310,6 @@ export const fetchUploadRealAccount = async (
       `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${strategyId}`,
       formData,
       {
-        params: {
-          displayName,
-        },
         headers: {
           auth: authRole,
         },
@@ -328,7 +324,7 @@ export const fetchUploadRealAccount = async (
 //실계좌 이미지 삭제
 export const fetchDeleteRealAccount = async (
   strategyId: number,
-  liveAccountId: number,
+  liveAccountId: number[],
   authRole: UserRole
 ) => {
   try {

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -327,13 +327,12 @@ export const fetchDeleteRealAccount = async (
   liveAccountId: number[],
   authRole: UserRole
 ) => {
+  const body = liveAccountId;
   try {
     const req = await apiClient.delete(
-      `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${liveAccountId}`,
+      `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${strategyId}`,
       {
-        params: {
-          strategyId,
-        },
+        data: body,
         headers: {
           auth: authRole,
         },

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -271,3 +271,80 @@ export const fetchEndStrategey = async (strategyId: number, authRole: UserRole) 
     console.error('failed to fetch request strategy terminated', error);
   }
 };
+
+//실계좌 이미지 조회
+export const fetchRealAccount = async (
+  strategyId: number,
+  authRole: UserRole,
+  page: number,
+  pageSize: number
+) => {
+  try {
+    const res = await apiClient.get(
+      `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${strategyId}/list`,
+      {
+        params: {
+          page,
+          pageSize,
+        },
+        headers: {
+          auth: authRole,
+        },
+      }
+    );
+    return res.data;
+  } catch (error) {
+    console.error('failed to upload real-account-img', error);
+  }
+};
+
+//실계좌 이미지 업로드
+export const fetchUploadRealAccount = async (
+  strategyId: number,
+  displayName: string,
+  fileItem: File,
+  authRole: UserRole
+) => {
+  const formData = createFormDataRequest({ file: fileItem });
+  try {
+    const req = await apiClient.post(
+      `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${strategyId}`,
+      formData,
+      {
+        params: {
+          displayName,
+        },
+        headers: {
+          auth: authRole,
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to post real-account-img', error);
+  }
+};
+
+//실계좌 이미지 삭제
+export const fetchDeleteRealAccount = async (
+  strategyId: number,
+  liveAccountId: number,
+  authRole: UserRole
+) => {
+  try {
+    const req = await apiClient.delete(
+      `${API_ENDPOINTS.STRATEGY.UPLOAD_ACCOUNT_IMG}/${liveAccountId}`,
+      {
+        params: {
+          strategyId,
+        },
+        headers: {
+          auth: authRole,
+        },
+      }
+    );
+    return req.data;
+  } catch (error) {
+    console.error('failed to post real-account-img', error);
+  }
+};

--- a/src/components/page/strategy-detail/ImgSection.tsx
+++ b/src/components/page/strategy-detail/ImgSection.tsx
@@ -7,16 +7,21 @@ interface imgSectionProps {
   name: string;
   id: number;
   isSelected: boolean;
+  isSelfed: boolean;
   onSelect: (id: number) => void;
 }
 
-const ImgSection = ({ img, id, name, isSelected, onSelect }: imgSectionProps) => (
+const ImgSection = ({ img, id, name, isSelected, isSelfed, onSelect }: imgSectionProps) => (
   <div css={imgWrapper}>
     <div css={imgContent}>
       <img src={img} alt={img} css={imgSection} />
-      <Checkbox checked={isSelected ?? false} onChange={() => onSelect(id)}>
+      {isSelfed ? (
+        <Checkbox checked={isSelected ?? false} onChange={() => onSelect(id)}>
+          <div>{name}</div>
+        </Checkbox>
+      ) : (
         <div>{name}</div>
-      </Checkbox>
+      )}
     </div>
   </div>
 );

--- a/src/components/page/strategy-detail/ImgSection.tsx
+++ b/src/components/page/strategy-detail/ImgSection.tsx
@@ -5,16 +5,17 @@ import Checkbox from '@/components/common/Checkbox';
 interface imgSectionProps {
   img: string;
   name: string;
+  id: number;
   isSelected: boolean;
-  onSelect: (checked: boolean) => void;
+  onSelect: (id: number) => void;
 }
 
-const ImgSection = ({ img, name, isSelected, onSelect }: imgSectionProps) => (
+const ImgSection = ({ img, id, name, isSelected, onSelect }: imgSectionProps) => (
   <div css={imgWrapper}>
     <div css={imgContent}>
       <img src={img} alt={img} css={imgSection} />
-      <Checkbox checked={isSelected} onChange={onSelect}>
-        <div css={imgName}>{name}</div>
+      <Checkbox checked={isSelected ?? false} onChange={() => onSelect(id)}>
+        <div>{name}</div>
       </Checkbox>
     </div>
   </div>
@@ -36,5 +37,4 @@ const imgContent = css`
   flex-direction: column;
   gap: 10px;
 `;
-const imgName = css``;
 export default ImgSection;

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -7,74 +7,103 @@ import { MdCheck } from 'react-icons/md';
 import ImgSection from '../ImgSection';
 
 import Button from '@/components/common/Button';
+import Loader from '@/components/common/Loading';
 import Modal from '@/components/common/Modal';
 import Pagination from '@/components/common/Pagination';
 import Toast from '@/components/common/Toast';
+import { useDeleteAccountImg, useUploadAccountImg } from '@/hooks/mutations/useAccountMutation';
+import { useFetchAccountImg } from '@/hooks/queries/useAccountImg';
+import usePagination from '@/hooks/usePagination';
 import useModalStore from '@/stores/modalStore';
 import useToastStore from '@/stores/toastStore';
 import theme from '@/styles/theme';
-import { isValidCheckImg } from '@/utils/fileHelper';
+import { UserRole } from '@/types/route';
+import { isValidDateFormat } from '@/utils/fileHelper';
 
-interface imgFileDetail {
-  imgUrl: string;
-  name: string;
+interface AccountProps {
+  strategyId: number;
+  role?: UserRole;
 }
 
-const paginatedData = (data: imgFileDetail[], currentPage: number, pageSize = 8) => {
-  const startIdx = (currentPage - 1) * pageSize;
-  const endIdx = startIdx + pageSize;
-  return data.slice(startIdx, endIdx);
-};
+interface AccountImgProps {
+  liveAccountId: number;
+  fileName: string;
+  fileLink: string;
+}
 
-const AccountVerify = () => {
-  const [fileNames, setFileNames] = useState<imgFileDetail[]>([]);
-  const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
-  const [page, setPage] = useState(1);
+const AccountVerify = ({ strategyId, role }: AccountProps) => {
+  const { pagination, setPage } = usePagination(1, 8);
+  const { accountImgs, page, pageSize, totalPages, isLoading } = useFetchAccountImg(
+    strategyId,
+    role as UserRole,
+    pagination.currentPage - 1,
+    pagination.pageSize
+  );
+  const { mutate: uploadAccount } = useUploadAccountImg();
+  const { mutate: deleteAccount } = useDeleteAccountImg();
+  const [selectedFiles, setSelectedFiles] = useState<number[]>([]);
   const { openModal } = useModalStore();
   const { showToast, message, hideToast, isToastVisible } = useToastStore();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const limit = 8;
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
   };
 
   const handleUploadImg = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const imgFiles = e.target.files;
+    const imgFiles = e.target.files?.[0];
     if (imgFiles) {
-      const validFiles = Array.from(imgFiles).filter((file) => isValidCheckImg(file.name));
-
-      if (validFiles.length > 0) {
-        const newImgs = validFiles.map((file, idx) => ({
-          id: `${file.name}-${idx}`,
-          imgUrl: URL.createObjectURL(file),
-          name: file.name,
-        }));
-        setFileNames((prevImgs) => [...prevImgs, ...newImgs]);
-        e.target.value = '';
+      const isDuplicate = accountImgs.some(
+        (item: AccountImgProps) => item.fileName === imgFiles.name
+      );
+      if (isDuplicate) {
+        showToast('이미 실계좌 인증이 등록된 일자입니다.', 'error');
+        return;
+      }
+      if (isValidDateFormat(imgFiles.name)) {
+        uploadAccount({ strategyId, authRole: role as UserRole, fileItem: imgFiles });
+        showToast('실계좌 이미지가 등록되었습니다.');
       } else {
-        showToast('올바른 이미지를 등록해주세요.');
+        showToast('파일명은 YYYY.MM.DD형식으로 입력하세요.', 'error');
+        return;
       }
     }
   };
 
-  const handleSelectedImg = (imgUrl: string, checked: boolean) => {
-    setSelectedFiles((prevSelected) =>
-      checked ? [...prevSelected, imgUrl] : prevSelected.filter((url) => url !== imgUrl)
+  const handleSelectedImg = (imgId: number) => {
+    setSelectedFiles((prev) =>
+      prev.includes(imgId) ? prev.filter((item) => item !== imgId) : [...prev, imgId]
     );
   };
 
   const handleDeleteImg = () => {
-    openModal({
-      type: 'warning',
-      title: '이미지 삭제',
-      desc: `선택하신 ${selectedFiles.length}개의 이미지를 삭제하시겠습니까?`,
-      onAction: () => {
-        setFileNames((prevImgs) => prevImgs.filter((img) => !selectedFiles.includes(img.imgUrl)));
-        setSelectedFiles([]);
-      },
-    });
+    if (selectedFiles.length > 0) {
+      openModal({
+        type: 'warning',
+        title: '이미지 삭제',
+        desc: `선택하신 ${selectedFiles.length}개의 이미지를 삭제하시겠습니까?`,
+        onAction: () => {
+          deleteAccount({ strategyId, authRole: role as UserRole, liveAccountId: selectedFiles });
+          setSelectedFiles([]);
+        },
+      });
+    } else {
+      openModal({
+        type: 'warning',
+        title: '이미지 삭제',
+        desc: `선택된 이미지가 없습니다.`,
+        onAction: () => {},
+      });
+    }
   };
+
+  if (isLoading) {
+    return (
+      <div>
+        <Loader />
+      </div>
+    );
+  }
 
   return (
     <div css={accountWrapper}>
@@ -96,35 +125,30 @@ const AccountVerify = () => {
           </Button>
           <input
             type='file'
-            accept='image/*'
+            accept='png ,jpeg, jpg, webp'
             ref={fileInputRef}
             onChange={handleUploadImg}
             style={{ display: 'none' }}
           />
         </div>
       </div>
-      {fileNames.length > 0 ? (
+      {accountImgs.length > 0 ? (
         <div css={imagesGrid}>
-          {paginatedData(fileNames, page, limit).map((item, idx) => (
+          {accountImgs.map((item: AccountImgProps) => (
             <ImgSection
-              key={idx}
-              img={item.imgUrl}
-              name={item.name}
-              isSelected={selectedFiles.includes(item.imgUrl)}
-              onSelect={(checked) => handleSelectedImg(item.imgUrl, checked)}
+              key={item.liveAccountId}
+              img={item.fileLink}
+              id={item.liveAccountId}
+              name={item.fileName}
+              isSelected={selectedFiles.includes(item.liveAccountId)}
+              onSelect={handleSelectedImg}
             />
           ))}
         </div>
       ) : (
         <div css={noneUploaded}>업로드된 데이터가 없습니다.</div>
       )}
-
-      <Pagination
-        totalPage={Math.ceil(fileNames.length / limit)}
-        limit={limit}
-        page={page}
-        setPage={setPage}
-      />
+      <Pagination totalPage={totalPages} limit={pageSize} page={page - 1} setPage={setPage} />
       <Modal />
       <Toast message={message} onClose={hideToast} isVisible={isToastVisible} />
     </div>

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -23,6 +23,7 @@ import { isValidDateFormat } from '@/utils/fileHelper';
 interface AccountProps {
   strategyId: number;
   role?: UserRole;
+  isSelfed: boolean;
 }
 
 interface AccountImgProps {
@@ -31,7 +32,7 @@ interface AccountImgProps {
   fileLink: string;
 }
 
-const AccountVerify = ({ strategyId, role }: AccountProps) => {
+const AccountVerify = ({ strategyId, isSelfed, role }: AccountProps) => {
   const { pagination, setPage } = usePagination(1, 8);
   const { accountImgs, page, pageSize, totalPages, isLoading } = useFetchAccountImg(
     strategyId,
@@ -57,14 +58,17 @@ const AccountVerify = ({ strategyId, role }: AccountProps) => {
         (item: AccountImgProps) => item.fileName === imgFiles.name
       );
       if (isDuplicate) {
-        showToast('이미 실계좌 인증이 등록된 일자입니다.', 'error');
+        showToast('이미 실계좌 인증 이미지가 등록된 일자입니다.', 'error');
+        e.target.value = '';
         return;
       }
       if (isValidDateFormat(imgFiles.name)) {
         uploadAccount({ strategyId, authRole: role as UserRole, fileItem: imgFiles });
         showToast('실계좌 이미지가 등록되었습니다.');
+        e.target.value = '';
       } else {
-        showToast('파일명은 YYYY.MM.DD형식으로 입력하세요.', 'error');
+        showToast('파일명은 YYYY.MM.DD 형식으로 입력하세요.', 'error');
+        e.target.value = '';
         return;
       }
     }
@@ -107,31 +111,33 @@ const AccountVerify = ({ strategyId, role }: AccountProps) => {
 
   return (
     <div css={accountWrapper}>
-      <div css={headingStyle}>
-        <div css={textStyle}>
-          <MdCheck css={iconStyle} size={24} />
-          <div>
-            파일명은 YYYY.MM.DD 형식(예: 2024.11.15)으로 일간분석 테이블에 입력한 날짜와 동일하게
-            변경해주세요.
+      {isSelfed && (
+        <div css={headingStyle}>
+          <div css={textStyle}>
+            <MdCheck css={iconStyle} size={24} />
+            <div>
+              파일명은 YYYY.MM.DD 형식(예: 2024.11.15)으로 일간분석 테이블에 입력한 날짜와 동일하게
+              변경해주세요.
+            </div>
+          </div>
+          <div css={buttonArea}>
+            <Button variant='secondary' size='xs' width={89} onClick={handleUploadClick}>
+              <BiPlus />
+              추가
+            </Button>
+            <Button variant='neutral' size='xs' width={89} onClick={handleDeleteImg}>
+              삭제
+            </Button>
+            <input
+              type='file'
+              accept='.png,.jpeg,.jpg,.webp'
+              ref={fileInputRef}
+              onChange={handleUploadImg}
+              style={{ display: 'none' }}
+            />
           </div>
         </div>
-        <div css={buttonArea}>
-          <Button variant='secondary' size='xs' width={89} onClick={handleUploadClick}>
-            <BiPlus />
-            추가
-          </Button>
-          <Button variant='neutral' size='xs' width={89} onClick={handleDeleteImg}>
-            삭제
-          </Button>
-          <input
-            type='file'
-            accept='png ,jpeg, jpg, webp'
-            ref={fileInputRef}
-            onChange={handleUploadImg}
-            style={{ display: 'none' }}
-          />
-        </div>
-      </div>
+      )}
       {accountImgs.length > 0 ? (
         <div css={imagesGrid}>
           {accountImgs.map((item: AccountImgProps) => (
@@ -140,6 +146,7 @@ const AccountVerify = ({ strategyId, role }: AccountProps) => {
               img={item.fileLink}
               id={item.liveAccountId}
               name={item.fileName}
+              isSelfed={isSelfed}
               isSelected={selectedFiles.includes(item.liveAccountId)}
               onSelect={handleSelectedImg}
             />
@@ -148,7 +155,7 @@ const AccountVerify = ({ strategyId, role }: AccountProps) => {
       ) : (
         <div css={noneUploaded}>업로드된 데이터가 없습니다.</div>
       )}
-      <Pagination totalPage={totalPages} limit={pageSize} page={page - 1} setPage={setPage} />
+      <Pagination totalPage={totalPages} limit={pageSize} page={page + 1} setPage={setPage} />
       <Modal />
       <Toast message={message} onClose={hideToast} isVisible={isToastVisible} />
     </div>

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -62,15 +62,14 @@ const AccountVerify = ({ strategyId, isSelfed, role }: AccountProps) => {
         e.target.value = '';
         return;
       }
-      if (isValidDateFormat(imgFiles.name)) {
-        uploadAccount({ strategyId, authRole: role as UserRole, fileItem: imgFiles });
-        showToast('실계좌 이미지가 등록되었습니다.');
-        e.target.value = '';
-      } else {
+      if (!isValidDateFormat(imgFiles.name)) {
         showToast('파일명은 YYYY.MM.DD 형식으로 입력하세요.', 'error');
         e.target.value = '';
         return;
       }
+      uploadAccount({ strategyId, authRole: role as UserRole, fileItem: imgFiles });
+      showToast('실계좌 이미지가 등록되었습니다.');
+      e.target.value = '';
     }
   };
 

--- a/src/hooks/mutations/useAccountMutation.ts
+++ b/src/hooks/mutations/useAccountMutation.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { fetchDeleteRealAccount, fetchUploadRealAccount } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
+
+export const useUploadAccountImg = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      authRole,
+      fileItem,
+    }: {
+      strategyId: number;
+      authRole: UserRole;
+      fileItem: File;
+    }) => fetchUploadRealAccount(strategyId, fileItem, authRole),
+    onError: (error) => error.message,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accountImg'] });
+    },
+  });
+};
+
+export const useDeleteAccountImg = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      strategyId,
+      authRole,
+      liveAccountId,
+    }: {
+      strategyId: number;
+      authRole: UserRole;
+      liveAccountId: number[];
+    }) => fetchDeleteRealAccount(strategyId, liveAccountId, authRole),
+    onError: (error) => error.message,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accountImg'] });
+    },
+  });
+};

--- a/src/hooks/queries/useAccountImg.ts
+++ b/src/hooks/queries/useAccountImg.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchRealAccount } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
+
+export const useFetchAccountImg = (
+  strategyId: number,
+  role: UserRole,
+  page: number,
+  pageSize: number
+) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['accountImg', strategyId, role, page, pageSize],
+    queryFn: async () => {
+      const res = await fetchRealAccount(strategyId, role, page, pageSize);
+      return {
+        accouotImgs: res.data,
+        page: res.currentPage,
+        totalPages: res.totalPages,
+        limit: res.pageSize,
+      };
+    },
+    enabled: !!strategyId,
+  });
+
+  return {
+    accountImgs: data?.accouotImgs,
+    isLoading,
+    page: data?.page,
+    totalPages: data?.totalPages,
+    pageSize: data?.limit,
+  };
+};

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -58,6 +58,9 @@ const StrategyDetailPage = () => {
   const { data: approveState } = useFetchApproveState(Number(strategyId), role) || '';
   const isApproved = dailyAnalysis?.length >= 3 || approveState?.isApproved === 'N';
   const isTerminated = strategy?.strategyStatusCode === 'STRATEGY_OPERATION_TERMINATED';
+  const isPrivate =
+    user?.role === 'ROLE_ADMIN' ||
+    (user?.role === 'ROLE_TRADER' && user?.memberId === strategy.memberId);
   const { isToastVisible, hideToast, message, type } = useToastStore();
 
   const statisticsTableData = (
@@ -84,7 +87,9 @@ const StrategyDetailPage = () => {
     },
     {
       title: '실계좌인증',
-      component: <AccountVerify strategyId={Number(strategyId)} role={user?.role} />,
+      component: (
+        <AccountVerify strategyId={Number(strategyId)} role={user?.role} isSelfed={isPrivate} />
+      ),
     },
     {
       title: '일간분석',

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -84,7 +84,7 @@ const StrategyDetailPage = () => {
     },
     {
       title: '실계좌인증',
-      component: <AccountVerify />,
+      component: <AccountVerify strategyId={Number(strategyId)} role={user?.role} />,
     },
     {
       title: '일간분석',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

전략 상세 페이지 내 실계좌 인증 이미지 조회, 등록, 삭제 API 반영해서 기능 구현했습니다.
타 트레이더, 비로그인한 사용자의 경우 등록, 삭제, 체크박스가 보이지 않도록 분기처리 했습니다. (본인과 관리자만 보임)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![Dec-03-2024 14-35-04](https://github.com/user-attachments/assets/983a6b2b-4af8-487b-ac38-c00af09949c3)



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

사용자 역할에 기반한 접근 제어를 통해 실계정 인증 이미지 관리 기능을 구현하여 이미지 보기, 등록 및 삭제를 포함합니다.

새로운 기능:
- 전략 세부 페이지에서 실계정 인증 이미지를 보고, 등록하고, 삭제하는 기능을 구현합니다.

개선 사항:
- 비로그인 사용자 및 다른 트레이더에게는 등록, 삭제 및 체크박스 옵션을 숨기고 소유자와 관리자에게만 보이도록 조건부 렌더링을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement real account verification image management, including viewing, registering, and deleting images, with access control based on user roles.

New Features:
- Implement functionality to view, register, and delete real account verification images on the strategy detail page.

Enhancements:
- Add conditional rendering to hide registration, deletion, and checkbox options for non-logged-in users and other traders, making them visible only to the owner and admin.

</details>