### PR TITLE
[Fix] 비공개, 미승인 상태인 전략 접근할 수 없도록 리다이렉트 처리

### DIFF
--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -14,6 +14,7 @@ import Toast from '@/components/common/Toast';
 import { useDeleteAccountImg, useUploadAccountImg } from '@/hooks/mutations/useAccountMutation';
 import { useFetchAccountImg } from '@/hooks/queries/useAccountImg';
 import usePagination from '@/hooks/usePagination';
+import { useAuthStore } from '@/stores/authStore';
 import useModalStore from '@/stores/modalStore';
 import useToastStore from '@/stores/toastStore';
 import theme from '@/styles/theme';
@@ -23,6 +24,7 @@ import { isValidDateFormat } from '@/utils/fileHelper';
 interface AccountProps {
   strategyId: number;
   role?: UserRole;
+  userId: string;
   isSelfed: boolean;
 }
 
@@ -32,7 +34,8 @@ interface AccountImgProps {
   fileLink: string;
 }
 
-const AccountVerify = ({ strategyId, isSelfed, role }: AccountProps) => {
+const AccountVerify = ({ strategyId, isSelfed, role, userId }: AccountProps) => {
+  const { user } = useAuthStore();
   const { pagination, setPage } = usePagination(1, 8);
   const { accountImgs, page, pageSize, totalPages, isLoading } = useFetchAccountImg(
     strategyId,
@@ -110,7 +113,7 @@ const AccountVerify = ({ strategyId, isSelfed, role }: AccountProps) => {
 
   return (
     <div css={accountWrapper}>
-      {isSelfed && (
+      {isSelfed && userId === user?.memberId && (
         <div css={headingStyle}>
           <div css={textStyle}>
             <MdCheck css={iconStyle} size={24} />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

비공개 상태이거나 승인되지 않은 전략에 관리자 및 작성자 이외의 사용자가 임의로 접근 시 Not Found 페이지로 리다이렉트 처리
트레이더로 로그인 했을 때 저의 잘못된 분기처리 이슈로 인해 페이지에 접근하지 못하는 이슈.. 수정했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

사용자를 Not Found 페이지로 리디렉션하여 비공개 또는 승인되지 않은 전략에 대한 무단 접근을 차단하고, 잘못된 분기 로직으로 인해 거래자들이 겪는 접근 문제를 해결합니다.

버그 수정:
- 잘못된 분기 로직으로 인해 거래자들이 특정 페이지에 접근할 수 없었던 문제를 수정합니다.

개선 사항:
- 적절한 권한 없이 비공개 또는 승인되지 않은 전략에 접근하려고 할 때 사용자를 Not Found 페이지로 리디렉션합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Block unauthorized access to private or unapproved strategies by redirecting users to a Not Found page and fix access issues for traders due to incorrect branching logic.

Bug Fixes:
- Fix an issue where traders could not access certain pages due to incorrect branching logic.

Enhancements:
- Redirect users to a Not Found page when they attempt to access private or unapproved strategies without proper authorization.

</details>