### PR TITLE
[Feat] 관리자이메일로 로그인 시 상단에 로그아웃 버튼 추가 (#292)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -190,7 +190,5 @@ const searchAndMyPageContainer = (user: User | null) => css`
 const buttonStyle = css`
   margin: 0 8px 0 12px;
 `;
-const iconStyle = css`
-  margin-right: 4px;
-`;
+
 export default Header;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,7 +14,6 @@ import Loader from '@/components/common/Loading';
 import TraderStats from '@/components/page/home/TraderStats';
 import { ROUTES } from '@/constants/routes';
 import { useFetchStrategyTraderCount } from '@/hooks/queries/useFetchStrategyTraderCount';
-import DatePickerTest from '@/pages/test-page/DatepickerTestPage';
 import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
 
@@ -108,7 +107,6 @@ const HomePage = () => {
 
   return (
     <>
-      <DatePickerTest />
       {/* 투자자Main */}
       <section css={investorSectionStyle}>
         <div css={contentStyle}>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/fc3a9150-56a6-4061-b9b6-9d559942349c

![스크린샷 2024-12-03 오후 11 57 33](https://github.com/user-attachments/assets/723cdab1-1e3c-41ce-964f-0d18c258251c)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

헤더에 관리자 사용자를 위한 로그아웃 버튼을 추가하고 사용자 유형에 따라 레이아웃을 동적으로 조정하도록 헤더 컴포넌트를 리팩토링합니다.

새로운 기능:
- 관리자 이메일로 로그인했을 때 헤더에 관리자 사용자를 위한 로그아웃 버튼을 추가합니다.

개선 사항:
- 사용자 유형에 따라 검색 및 마이 페이지 컨테이너에 동적 간격을 포함하도록 헤더 컴포넌트를 리팩토링합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a logout button for admin users in the header and refactor the header component to adjust layout dynamically based on user type.

New Features:
- Add a logout button for admin users in the header when logged in with an admin email.

Enhancements:
- Refactor the header component to include a dynamic gap in the search and my page container based on user type.

</details>