### PR TITLE
[refactor] 전략관리승인목록의 전략상태컴포넌트 추가 및 메뉴 알람 제거

### DIFF
--- a/src/components/navigation/AdminNav.tsx
+++ b/src/components/navigation/AdminNav.tsx
@@ -19,7 +19,6 @@ const AdminNav = () => {
     {
       to: `${ROUTES.ADMIN.STRATEGY.APPROVAL}`,
       label: '전략승인관리',
-      notificationCount: 1,
     },
     {
       to: `${ROUTES.ADMIN.STOCK_TYPE.LIST}`,

--- a/src/components/page/admin/StrategyOperationStatus.tsx
+++ b/src/components/page/admin/StrategyOperationStatus.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const STATUS_LABELS: Record<string, string> = {
+  STRATEGY_OPERATION_UNDER_MANAGEMENT: '운용 중',
+  STRATEGY_OPERATION_TERMINATED: '운용 종료',
+};
+
+const StrategyOperationStatus = ({ status }: { status: string }) => (
+  <div css={getStatusStyle(status)}>{STATUS_LABELS[status] || '상태 없음'}</div>
+);
+
+const getStatusStyle = (status: string) => {
+  switch (status) {
+    case 'STRATEGY_OPERATION_UNDER_MANAGEMENT':
+      return css`
+        display: flex;
+        align-items: center;
+        ${theme.textStyle.captions.caption1};
+
+        &::before {
+          content: '';
+          width: 8px;
+          height: 8px;
+          background-color: ${theme.colors.teal[400]};
+          border-radius: 50%;
+          margin-right: 6px;
+        }
+      `;
+    case 'STRATEGY_OPERATION_TERMINATED':
+      return css`
+        display: flex;
+        align-items: center;
+        ${theme.textStyle.captions.caption1};
+
+        &::before {
+          content: '';
+          width: 8px;
+          height: 8px;
+          background-color: ${theme.colors.gray[200]};
+          border-radius: 50%;
+          margin-right: 6px;
+        }
+      `;
+    default:
+      return css`
+        display: flex;
+        align-items: center;
+        ${theme.textStyle.captions.caption1};
+      `;
+  }
+};
+
+export default StrategyOperationStatus;

--- a/src/pages/admin/strategy/StrategyApprovalListPage.tsx
+++ b/src/pages/admin/strategy/StrategyApprovalListPage.tsx
@@ -8,6 +8,7 @@ import Modal from '@/components/common/Modal';
 import Pagination from '@/components/common/Pagination';
 import Toast from '@/components/common/Toast';
 import RejectTextarea from '@/components/page/admin/RejectTextarea';
+import StrategyOperationStatus from '@/components/page/admin/StrategyOperationStatus';
 import { ROUTES } from '@/constants/routes';
 import {
   useApproveStrategy,
@@ -173,10 +174,14 @@ const StrategyApprovalListPage = () => {
                       </div>
                     </div>
                   </td>
-                  <td>너는 잠시 빈값으로 살아라...</td>
+                  <td>
+                    <StrategyOperationStatus status={strategy.strategyStatus} />
+                  </td>
                   <td>{formatDate(strategy.requestDatetime)}</td>
                   <td>
-                    <img src={strategy.tradingTypeIcon} alt='icon' />
+                    <div css={tradingTypeIconContainer}>
+                      <img src={strategy.tradingTypeIcon} alt='icon' />
+                    </div>
                   </td>
                   <td>{getPostStatus(strategy.isPosted)}</td>
                   <td>
@@ -341,6 +346,15 @@ const colgroupStyle = css`
   }
   col:nth-of-type(6) {
     width: 160px;
+  }
+`;
+
+const tradingTypeIconContainer = css`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  img {
+    width: 32px;
   }
 `;
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #282

## 📋 작업 내용

1. 전략관리승인목록의 전략상태컴포넌트 추가
2. 메뉴에 전략승인 알람 숫자 제거

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/62b8ddd4-8b0c-4cdf-be8d-2a6a4c6c5ab5

https://github.com/user-attachments/assets/5fcd11f0-fc1c-4061-8584-647c72d2c7a3



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

새로운 컴포넌트인 StrategyOperationStatus를 도입하여 전략 승인 목록에서 전략 상태를 표시하고 관리자 탐색 메뉴에서 전략 승인 알림 수를 제거합니다.

새로운 기능:
- 전략 승인 목록에서 전략의 상태를 표시하기 위해 StrategyOperationStatus 컴포넌트를 추가합니다.

개선 사항:
- 전략 승인 목록 페이지에서 거래 유형 아이콘을 컨테이너 내 중앙에 배치합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new component, StrategyOperationStatus, to display strategy statuses in the strategy approval list and remove the strategy approval notification count from the admin navigation menu.

New Features:
- Add StrategyOperationStatus component to display the status of strategies in the strategy approval list.

Enhancements:
- Center the trading type icon within its container on the strategy approval list page.

</details>