### PR TITLE
[feat] 상단 헤더의 트레이더메뉴 전체조회 페이지 api 구현

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -8,7 +8,7 @@ import {
 } from '@/types/search';
 
 interface SearchParams {
-  keyword: string;
+  keyword?: string;
   page?: number;
   pageSize?: number;
   sortOption?: 'strategyCnt' | 'latestSignup';

--- a/src/hooks/queries/useSearch.ts
+++ b/src/hooks/queries/useSearch.ts
@@ -10,11 +10,13 @@ import {
 
 export const useSearchTraders = (
   keyword: string,
-  sortOption: 'strategyCnt' | 'latestSignup' = 'strategyCnt'
+  sortOption: 'strategyCnt' | 'latestSignup' = 'strategyCnt',
+  options: { page?: number; pageSize?: number } = {}
 ): UseQueryResult<SearchResponse<SearchedTrader>> => {
   console.log('useSearchTraders Hook Parameters:', { keyword, sortOption });
+  const { page = 0, pageSize = 4 } = options;
   return useQuery({
-    queryKey: ['traders', keyword, sortOption],
+    queryKey: ['traders', keyword, sortOption, page, pageSize],
     queryFn: async () => searchTraders({ keyword }),
     enabled: !!keyword,
   });

--- a/src/pages/search/SearchResultsInTrader.tsx
+++ b/src/pages/search/SearchResultsInTrader.tsx
@@ -21,7 +21,7 @@ const SearchResultsInTrader = () => {
   const { data: traderResults, isLoading: isTraderLoading } = useSearchTraders(keyword, sortOption); // 트레이더 검색 결과
 
   const sortOptions = [
-    { label: '전략 많은 수', value: 'strategyCnt' },
+    { label: '전략 많은 순', value: 'strategyCnt' },
     { label: '신규 등록 순', value: 'latestSignup' },
   ];
 
@@ -49,7 +49,7 @@ const SearchResultsInTrader = () => {
           }}
           type='sm'
           width='200px'
-          defaultLabel='전략많은 순'
+          defaultLabel='전략 많은 순'
         />
       </div>
       <TraderList traders={mappedTraders} />

--- a/src/pages/trader/TraderListPage.tsx
+++ b/src/pages/trader/TraderListPage.tsx
@@ -1,233 +1,66 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { css } from '@emotion/react';
 
-import TraderUserImage3 from '@/assets/images/ani_trader.png';
-import TraderUserImage1 from '@/assets/images/apt_trader.png';
-import TraderUserImage2 from '@/assets/images/nimo_trader.png';
+import Loader from '@/components/common/Loading';
 import PageHeader from '@/components/common/PageHeader';
 import Pagination from '@/components/common/Pagination';
 import Select from '@/components/common/Select';
 import TraderList from '@/components/common/TraderList';
+import { useSearchTraders } from '@/hooks/queries/useSearch';
 import theme from '@/styles/theme';
+import { mapToTraderData } from '@/utils/mappers';
 
 const desc = [{ text: '관심 있는 트레이더를 찾아 전략과 프로필을 확인해보세요.' }];
 
 const sortOptions = [
-  { label: '전략 많은 순', value: 'most_strategies' },
-  { label: '신규 트레이더', value: 'new_traders' },
-];
-
-const generateTraders = [
-  {
-    traderId: '1',
-    name: '트레이더 김철수',
-    profileImage: TraderUserImage1,
-    description: '안정적인 장기 투자를 선호하는 전문 트레이더입니다.',
-    strategiesCount: 3050,
-    createdAt: '2024-11-01',
-  },
-  {
-    traderId: '2',
-    name: '트레이더 닉네임 이렇게꺼지 길어져도 되는지까지 한번 보자유',
-    profileImage: TraderUserImage2,
-    description: '단기 수익을 추구하며, 높은 변동성을 활용한 전략이 특징입니다.',
-    strategiesCount: 1500,
-    createdAt: '2024-04-27',
-  },
-  {
-    traderId: '3',
-    name: '내가 바로 투자 짱',
-    profileImage: TraderUserImage3,
-    description: '주도주로 매매하면 수익은 크고 손실은 작다! 믿는 종목에 발등 찍힌다.',
-    strategiesCount: 450,
-    createdAt: '2024-05-02',
-  },
-  {
-    traderId: '4',
-    name: '투자는 내꺼야',
-    profileImage: '/path/to/profile/image4.png',
-    description: '투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야투자는 내꺼야',
-    strategiesCount: 1200,
-    createdAt: '2024-10-07',
-  },
-  {
-    traderId: '5',
-    name: '이븐하게 구워줄게요',
-    profileImage: '/path/to/profile/image5.png',
-    description: '모수에서 먹으면 냠냠 맛있어요.',
-    strategiesCount: 8000,
-    createdAt: '2024-03-20',
-  },
-  {
-    traderId: '6',
-    name: '비트코인 매니아',
-    profileImage: '/path/to/profile/image6.png',
-    description: '암호화폐 시장의 상승과 하락을 모두 잡습니다.',
-    strategiesCount: 2000,
-    createdAt: '2024-06-15',
-  },
-  {
-    traderId: '7',
-    name: '글로벌 트레이더',
-    profileImage: '/path/to/profile/image7.png',
-    description: '전 세계 다양한 시장에 투자 경험이 풍부합니다.',
-    strategiesCount: 1800,
-    createdAt: '2024-07-19',
-  },
-  {
-    traderId: '8',
-    name: '성장주 전문가',
-    profileImage: '/path/to/profile/image8.png',
-    description: '고성장 기업 발굴 전문가입니다.',
-    strategiesCount: 1450,
-    createdAt: '2024-08-13',
-  },
-  {
-    traderId: '9',
-    name: '가치주 매니저',
-    profileImage: '/path/to/profile/image9.png',
-    description: '가치투자로 장기 수익률을 극대화합니다.',
-    strategiesCount: 950,
-    createdAt: '2024-02-14',
-  },
-  {
-    traderId: '10',
-    name: '숏 트레이더',
-    profileImage: '/path/to/profile/image10.png',
-    description: '숏 포지션으로 하락장을 기회로 삼습니다.',
-    strategiesCount: 750,
-    createdAt: '2024-11-01',
-  },
-  {
-    traderId: '11',
-    name: '테마주 트레이더',
-    profileImage: '/path/to/profile/image11.png',
-    description: '시장의 핫한 테마를 선점하는 전략가입니다.',
-    strategiesCount: 2100,
-    createdAt: '2024-01-22',
-  },
-  {
-    traderId: '12',
-    name: '배당주 투자자',
-    profileImage: '/path/to/profile/image12.png',
-    description: '안정적인 배당 수익을 목표로 투자합니다.',
-    strategiesCount: 1300,
-    createdAt: '2024-05-27',
-  },
-  {
-    traderId: '13',
-    name: '주식 초보 트레이더',
-    profileImage: '/path/to/profile/image13.png',
-    description: '초보지만 꾸준히 배우며 성장 중입니다.',
-    strategiesCount: 300,
-    createdAt: '2024-03-08',
-  },
-  {
-    traderId: '14',
-    name: '옵션 트레이더',
-    profileImage: '/path/to/profile/image14.png',
-    description: '옵션 거래를 활용한 고수익 추구가 특징입니다.',
-    strategiesCount: 1150,
-    createdAt: '2024-06-01',
-  },
-  {
-    traderId: '15',
-    name: '퀀트 투자 전문가',
-    profileImage: '/path/to/profile/image15.png',
-    description: '데이터 기반의 퀀트 전략으로 투자합니다.',
-    strategiesCount: 2200,
-    createdAt: '2024-10-20',
-  },
-  {
-    traderId: '16',
-    name: '리스크 관리 전문가',
-    profileImage: '/path/to/profile/image16.png',
-    description: '리스크 최소화와 안정적 수익을 목표로 합니다.',
-    strategiesCount: 1600,
-    createdAt: '2024-04-02',
-  },
-  {
-    traderId: '17',
-    name: 'ETF 트레이더',
-    profileImage: '/path/to/profile/image17.png',
-    description: 'ETF로 다양한 시장에 손쉽게 투자합니다.',
-    strategiesCount: 1400,
-    createdAt: '2024-09-25',
-  },
-  {
-    traderId: '18',
-    name: '크립토 고수',
-    profileImage: '/path/to/profile/image18.png',
-    description: '암호화폐에서 최적의 투자 전략을 구사합니다.',
-    strategiesCount: 1850,
-    createdAt: '2024-07-05',
-  },
-  {
-    traderId: '19',
-    name: '펀드 매니저',
-    profileImage: '/path/to/profile/image19.png',
-    description: '펀드 관리 경험이 풍부한 투자자입니다.',
-    strategiesCount: 2800,
-    createdAt: '2024-08-23',
-  },
-  {
-    traderId: '20',
-    name: '기술주 애호가',
-    profileImage: '/path/to/profile/image20.png',
-    description: '첨단 기술 관련 주식에 주로 투자합니다.',
-    strategiesCount: 1950,
-    createdAt: '2024-02-07',
-  },
+  { label: '전략 많은 순', value: 'strategyCnt' },
+  { label: '신규 등록 순', value: 'latestSignup' },
 ];
 
 const TraderListPage = () => {
-  const traders = generateTraders;
-  const [page, setPage] = useState(1);
-  const [sortBy, setSortBy] = useState('');
-  const limit = 14; // 한 페이지당 2칸씩*7줄
-  const totalPages = Math.ceil(traders.length / limit);
+  const [sortOption, setSortOption] = useState<'strategyCnt' | 'latestSignup'>('strategyCnt');
+  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
+  const { data: traderResults, isLoading: isTraderLoading } = useSearchTraders('', sortOption, {
+    page: currentPage - 1, // 페이지는 0부터 시작
+    pageSize: 14,
+  }); // 트레이더 검색 결과
 
-  const sortedTraders = [...traders].sort((a, b) => {
-    if (sortBy === 'most_strategies') {
-      return b.strategiesCount - a.strategiesCount; // 전략 많은 순으로 정렬
-    } else if (sortBy === 'new_traders') {
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(); // 등록일 내림차순
-    }
-    return 0;
-  });
+  const mappedTraders = traderResults?.data.map(mapToTraderData) ?? [];
 
-  const currentPageData = sortedTraders.slice((page - 1) * limit, page * limit);
-
-  // strategiesCount 기준으로 상위 10명을 식별
-  const badgeRank = [...traders]
-    .sort((a, b) => b.strategiesCount - a.strategiesCount)
-    .slice(0, 10)
-    .map((trader) => trader.traderId);
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [page]);
-
+  if (isTraderLoading) {
+    return <Loader />;
+  }
   return (
     <div>
       <PageHeader title='트레이더' desc={desc} descType='center' />
       <div css={traderListContainerStyle}>
         <div css={filterBarContainerStyle}>
           <div css={totalStyle}>
-            Total <span>{traders.length}</span>
+            Total <span>{traderResults?.totalElements ?? 0}</span>
           </div>
           <Select
             options={sortOptions}
-            onChange={(option) => setSortBy(option.value)}
-            defaultLabel='기본 등록 순'
+            onChange={(option) => {
+              setSortOption(option.value as 'strategyCnt' | 'latestSignup');
+              setCurrentPage(1); // 정렬 변경시 첫 페이지로 이동
+            }}
             type='sm'
-            width='160px'
+            width='200px'
+            defaultLabel='전략 많은 순'
           />
         </div>
         <div css={listContainerStyle}>
-          <TraderList traders={currentPageData} badgeRank={badgeRank} />
-          <Pagination totalPage={totalPages} limit={limit} page={page} setPage={setPage} />
+          <TraderList
+            traders={mappedTraders}
+            badgeRank={mappedTraders.map((trader) => trader.traderId)}
+          />
+          <Pagination
+            totalPage={traderResults?.totalPages ?? 1}
+            limit={10}
+            page={currentPage}
+            setPage={setCurrentPage}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
전략검색api를 활용
keyword를 옵셔널로 바꿈
전략검색 때는 4개가 조회

트레이더메뉴 전체조회 페이지에서는 14개가 조회

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

트레이더 데이터가 없어서... 테스트는 오늘 지나고 가능

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

트레이더 메뉴 페이지에서 모든 트레이더를 가져오는 API를 구현하여 페이지 매김 및 전략 수 또는 최신 가입일로 정렬할 수 있도록 합니다. TraderListPage를 리팩토링하여 새로운 useSearchTraders 훅을 사용하여 동적 데이터 가져오기를 활용하고, 구성 요소 전반에 걸쳐 일관성을 유지하기 위해 정렬 옵션을 업데이트합니다.

새로운 기능:
- 페이지 매김 및 정렬 옵션과 함께 트레이더 메뉴 페이지에서 모든 트레이더를 가져오는 API를 구현합니다.

개선 사항:
- TraderListPage를 리팩토링하여 새로운 useSearchTraders 훅을 사용하여 트레이더 데이터를 동적으로 가져옵니다.
- 트레이더 목록 및 검색 결과의 정렬 옵션을 일관된 레이블과 값으로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement an API to fetch all traders for the trader menu page, allowing pagination and sorting by strategy count or latest signup. Refactor TraderListPage to utilize the new useSearchTraders hook for dynamic data fetching, and update sorting options for consistency across components.

New Features:
- Implement API for fetching all traders on the trader menu page with pagination and sorting options.

Enhancements:
- Refactor TraderListPage to use the new useSearchTraders hook for fetching trader data dynamically.
- Update sorting options in the trader list and search results to use consistent labels and values.

</details>