### PR TITLE
[Feat] 트레이더 나의 전략 조회 기능 구현 및 스타일/문구 수정

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -35,6 +35,9 @@ export const API_ENDPOINTS = {
     TRADER_STATS: '/api/strategies/strategy-trader-count', //트레이더 통계조회 (트레이더 수, 전략 수)
     UPLOAD_ACCOUNT_IMG: '/api/live-account-data', //실계좌 이미지 관리
   },
+  TRADERS: {
+    STRATEGIES: (traderId: string) => `/api/traders/${traderId}/strategies`, // 트레이더의 나의 전략 조회
+  },
   INQUIRY: '/api/consultations', // 나의 문의 , 문의 등록
   FILES: {
     PROFILE_URL: (memberId: string) => `/api/files/profile/${memberId}`, // 프로필 이미지 URL

--- a/src/api/traderStrategies.ts
+++ b/src/api/traderStrategies.ts
@@ -1,0 +1,33 @@
+import apiClient from '@/api/apiClient';
+import { API_ENDPOINTS } from '@/api/apiEndpoints';
+import { UserRole } from '@/types/route';
+import { handleAxiosError } from '@/utils/errorHandler';
+
+interface FetchTraderStrategiesParams {
+  role?: UserRole;
+  traderId: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export const fetchTraderStrategies = async ({
+  role,
+  traderId,
+  page = 0,
+  pageSize = 10,
+}: FetchTraderStrategiesParams) => {
+  try {
+    const response = await apiClient.get(API_ENDPOINTS.TRADERS.STRATEGIES(traderId), {
+      headers: {
+        Auth: role,
+      },
+      params: {
+        page,
+        pageSize,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    return handleAxiosError(error, '나의 전략 목록을 불러오는 중 에러가 발생했습니다.');
+  }
+};

--- a/src/hooks/queries/useFetchTraderStrategies.ts
+++ b/src/hooks/queries/useFetchTraderStrategies.ts
@@ -1,0 +1,56 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { fetchTraderStrategies } from '@/api/traderStrategies';
+import { UserRole } from '@/types/route';
+import { isValidAdminOrTraderRole } from '@/utils/roleUtils';
+
+interface UseFetchTraderStrategiesParams {
+  role?: UserRole;
+  traderId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export const useFetchTraderStrategies = ({
+  role,
+  traderId,
+  page = 0,
+  pageSize = 10,
+}: UseFetchTraderStrategiesParams) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['traderStrategies', { role, traderId, page, pageSize }],
+    queryFn: async () => {
+      if (!traderId) {
+        throw new Error('traderId가 없습니다.');
+      }
+
+      if (!isValidAdminOrTraderRole(role)) {
+        throw new Error(`유효하지 않은 역할입니다: ${role}`);
+      }
+
+      const res = await fetchTraderStrategies({ role, traderId, page, pageSize });
+
+      return {
+        strategies: res.data,
+        pagination: {
+          currentPage: res.page + 1,
+          totalPages: res.totalPages,
+          pageSize: res.pageSize,
+          totalElements: res.totalElements,
+        },
+      };
+    },
+    enabled: !!traderId && !!role,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    strategies: data?.strategies || [],
+    currentPage: data?.pagination.currentPage || 0,
+    totalPages: data?.pagination.totalPages || 0,
+    totalElements: data?.pagination.totalElements || 0,
+    pageSize: data?.pagination.pageSize || pageSize,
+    isLoading,
+    isError,
+  };
+};

--- a/src/pages/mypage/trader/InquiriesManagementPage.tsx
+++ b/src/pages/mypage/trader/InquiriesManagementPage.tsx
@@ -54,9 +54,9 @@ const InquiriesManagementPage = () => {
   return (
     <section css={myPageWrapperStyle}>
       <header css={myPageHeaderStyle}>
-        <h2>나의 문의</h2>
+        <h2>문의 관리</h2>
         <p>
-          총 <span>{totalElements}</span>개의 문의 내역이 있습니다
+          총 <span>{totalElements}</span>개의 문의가 있습니다
         </p>
       </header>
 

--- a/src/pages/mypage/trader/TraderMyPage.tsx
+++ b/src/pages/mypage/trader/TraderMyPage.tsx
@@ -1,22 +1,49 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
+import Loader from '@/components/common/Loading';
 import Pagination from '@/components/common/Pagination';
 import StrategyList from '@/components/common/StrategyList';
 import { ROUTES } from '@/constants/routes';
-import useFetchStrategyList from '@/hooks/queries/useFetchStrategyList';
+import { useFetchTraderStrategies } from '@/hooks/queries/useFetchTraderStrategies';
+import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
 
 const TraderMyPage = () => {
-  const [page, setPage] = useState(1);
-  const limit = 30;
+  const { user } = useAuthStore();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPageFromQuery = parseInt(searchParams.get('page') || '1', 10);
 
-  const { data } = useFetchStrategyList({
-    page: page - 1,
-    pageSize: limit,
-  });
+  const { strategies, isLoading, isError, totalPages, totalElements, pageSize } =
+    useFetchTraderStrategies({
+      traderId: user?.memberId,
+      role: user?.role,
+      page: currentPageFromQuery - 1,
+      pageSize: 10,
+    });
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({ page: String(page) });
+    window.scrollTo(0, 0);
+  };
+
+  if (isLoading) {
+    return (
+      <div css={myPageWrapperStyle}>
+        <Loader />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div css={myPageWrapperStyle}>
+        <p css={emptyStateWrapperStyle}>
+          데이터를 불러오는 데 실패했습니다. <br /> 다시 시도하거나 잠시 후에 확인해주세요.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div css={myPageWrapperStyle}>
@@ -24,13 +51,13 @@ const TraderMyPage = () => {
         <div>
           <h2>나의 전략</h2>
           <p>
-            총 <span>{data.totalElements}</span>개의 전략이 있습니다
+            총 <span>{totalElements}</span>개의 전략이 있습니다
           </p>
         </div>
         <Link to={ROUTES.MYPAGE.TRADER.STRATEGIES.CREATE}>전략등록</Link>
       </div>
       <div>
-        {data?.totalElements === 0 ? (
+        {totalElements === 0 ? (
           <p css={StrategyEmptyStyle}>
             아직 등록된 전략이 없습니다.
             <br /> &apos;전략 등록&apos; 버튼을 눌러 새로운 전략을 추가해보세요!
@@ -38,12 +65,17 @@ const TraderMyPage = () => {
         ) : (
           <div css={tableWrapperStyle}>
             <StrategyList
-              strategies={data.data}
-              startRank={(page - 1) * limit + 1}
+              strategies={strategies || []} // 데이터가 없을 경우 기본값 제공
+              // startRank={(page - 1) * limit + 1}
               containerWidth='875px'
               gridTemplate='minmax(0, 2.91fr) minmax(0, 2.29fr) minmax(0, 1.6fr) minmax(0, 1.37fr) minmax(0, 0.91fr) minmax(0, 0.91fr)'
             />
-            <Pagination totalPage={data.totalPages} limit={limit} page={page} setPage={setPage} />
+            <Pagination
+              totalPage={totalPages}
+              limit={pageSize}
+              page={currentPageFromQuery}
+              setPage={handlePageChange}
+            />
           </div>
         )}
       </div>
@@ -100,6 +132,16 @@ const tableWrapperStyle = css`
   flex-direction: column;
   align-items: center;
   gap: 56px;
+`;
+
+const emptyStateWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  text-align: center;
+  color: ${theme.colors.gray[400]};
 `;
 
 export default TraderMyPage;

--- a/src/pages/mypage/trader/TraderProfilePage.tsx
+++ b/src/pages/mypage/trader/TraderProfilePage.tsx
@@ -6,15 +6,20 @@ import PasswordChange from '@/components/page/mypage/PasswordChange';
 import ProfileManager from '@/components/page/mypage/ProfileManager';
 
 const TraderProfilePage = () => (
-  <>
+  <div css={myPageWrapperStyle}>
     <ProfileManager />
     <PasswordChange />
     <Button variant='ghostGray' customStyle={logoutStyle} size='sm'>
       <MdOutlineNoAccounts size={16} />
       <span>회원 탈퇴</span>
     </Button>
-  </>
+  </div>
 );
+
+const myPageWrapperStyle = css`
+  width: 955px;
+  border-radius: 8px;
+`;
 
 const logoutStyle = css`
   width: auto;

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -1,0 +1,5 @@
+import { ROLE_ADMIN, ROLE_TRADER } from '@/constants/roles';
+import { UserRole } from '@/types/route';
+
+export const isValidAdminOrTraderRole = (role?: UserRole): boolean =>
+  role === ROLE_TRADER || role === ROLE_ADMIN;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #311

## 📋 작업 내용

1. 트레이더 나의 전략 조회 기능 구현했습니다!
2. 부수적인 문의페이지 타이틀이나 프로필관리 css 수정했습니다!

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/e550f280-4af6-4f49-859e-bbae287dd737




## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

트레이더가 자신의 전략을 페이지네이션 및 오류 처리와 함께 볼 수 있는 기능을 구현합니다. 트레이더의 프로필 페이지 레이아웃을 개선하고 문의 관리 페이지를 명확성을 위해 업데이트합니다.

새로운 기능:
- 트레이더가 자신의 전략을 볼 수 있도록 페이지네이션 및 오류 처리를 포함한 기능을 구현합니다.

개선 사항:
- 더 나은 레이아웃 일관성을 위해 스타일이 적용된 래퍼를 포함하도록 트레이더의 프로필 페이지를 리팩토링합니다.
- 제목과 설명을 명확하게 하기 위해 문의 관리 페이지를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a feature for traders to view their own strategies with pagination and error handling. Enhance the trader's profile page layout and update the inquiries management page for improved clarity.

New Features:
- Implement a feature to allow traders to view their own strategies, including pagination and error handling.

Enhancements:
- Refactor the trader's profile page to include a styled wrapper for better layout consistency.
- Update the inquiries management page to improve the title and description for clarity.

</details>