### PR TITLE
[feat] 메인페이지 SMScore Top5 api명세서 따로 만들어주셔서 재api 연결 (#325)

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -34,6 +34,7 @@ export const API_ENDPOINTS = {
     UPDATE_FORM: '/api/strategies/update-form', // 전략 수정 조회
     TRADER_STATS: '/api/strategies/strategy-trader-count', //트레이더 통계조회 (트레이더 수, 전략 수)
     UPLOAD_ACCOUNT_IMG: '/api/live-account-data', //실계좌 이미지 관리
+    SM_SCORE: '/api/strategies/top5-sm-score', // 메인페이지 SMScore Top5
   },
   INQUIRY: '/api/consultations', // 나의 문의 , 문의 등록
   FILES: {

--- a/src/api/home/topStrategyRank.ts
+++ b/src/api/home/topStrategyRank.ts
@@ -2,27 +2,26 @@ import apiClient from '@/api/apiClient';
 import { API_ENDPOINTS } from '@/api/apiEndpoints';
 
 export interface RankingData {
-  strategyId: number;
-  strategyTitle: string;
-  traderNickname: string; // API에서 제공될 값(이름바꿔야함)
-  traderProfile: string; // API에서 제공될 값(이름바꿔야함)
-  cumulativeProfitLossRateList: number[];
-  dailyChange: number; // API에서 제공될 값(이름바꿔야함)
-  cumulativeProfitLossRate: number;
-  smScore: number;
+  strategyId: number; // 전략ID
+  strategyTitle: string; // 전략명
+  profilePath: string; // 트레이더 프로필 이미지
+  nickname: string; // 트레이더닉네임
+  cumulativeProfitLossRateList: number[]; // 그래프, 누적수익률
+  dailyPlRate: number; // 전일대비
 }
 
 export const fetchStrategies = async (): Promise<RankingData[]> => {
   try {
-    const response = await apiClient.get<{ data: RankingData[] }>(API_ENDPOINTS.STRATEGY.CREATE);
+    const response = await apiClient.get<{ data: RankingData[] }>(API_ENDPOINTS.STRATEGY.SM_SCORE);
 
     if (!response.data.data || response.data.data.length === 0) {
-      throw new Error('No strategy data available');
+      throw new Error('No top-ranking strategies available.');
     }
-    console.log('Fetched strategies:', response.data.data); // 여기에 콘솔 추가 ( 요건 완전히 연결 끝날때까지 갖고있을게영)
+
+    console.log('Fetched strategies data:', response.data);
     return response.data.data;
   } catch (error) {
-    console.error('Failed to fetch strategies:', error);
+    console.error('Failed to fetch top-ranking strategies:', error);
     throw error;
   }
 };

--- a/src/components/page/home/TopStrategyList.tsx
+++ b/src/components/page/home/TopStrategyList.tsx
@@ -8,12 +8,10 @@ import { formatRate } from '@/utils/statistics';
 interface RankingData {
   strategyId: number;
   strategyTitle: string;
-  traderNickname: string;
-  traderProfile: string;
+  profilePath: string;
+  nickname: string;
   cumulativeProfitLossRateList: number[];
-  dailyChange: number;
-  cumulativeProfitLossRate: number;
-  smScore: number;
+  dailyPlRate: number;
 }
 
 interface TopStrategyListProps {
@@ -23,9 +21,7 @@ interface TopStrategyListProps {
 const MAX_RANKS = 5;
 
 const TopStrategyList = ({ rankingData }: TopStrategyListProps) => {
-  const sortedData = [...rankingData].sort((a, b) => b.smScore - a.smScore);
-
-  const filledData = Array.from({ length: MAX_RANKS }, (_, i) => sortedData[i] || null);
+  const filledData = Array.from({ length: MAX_RANKS }, (_, i) => rankingData[i] || null);
 
   return (
     <div css={scoreContentStyle}>
@@ -48,11 +44,11 @@ const TopStrategyList = ({ rankingData }: TopStrategyListProps) => {
                 <div css={strategyTitleStyle}>{data.strategyTitle}</div>
                 <div css={traderInfoStyle}>
                   <img
-                    src={data.traderProfile || '/default-image.png'} // 기본 이미지 제공
-                    alt={`${data.traderNickname || '익명'} 이미지`}
+                    src={data.profilePath || '/default-image.png'}
+                    alt={`${data.nickname} 이미지`}
                     css={traderImageStyle}
                   />
-                  <span css={traderNicknameStyle}>{data.traderNickname || 'api명세서에없음'}</span>
+                  <span css={traderNicknameStyle}>{data.nickname}</span>
                 </div>
               </div>
               <div css={graphStyle}>
@@ -67,9 +63,9 @@ const TopStrategyList = ({ rankingData }: TopStrategyListProps) => {
                 )}
               </div>
               <div css={dailyChangeStyle}>
-                {data.dailyChange !== 0 ? (
+                {data.dailyPlRate !== 0 ? (
                   <>
-                    <span className='value'>{formatRate(data.dailyChange)}</span>
+                    <span className='value'>{formatRate(data.dailyPlRate)}</span>
                     <span className='percent'>%</span>
                   </>
                 ) : (
@@ -77,9 +73,13 @@ const TopStrategyList = ({ rankingData }: TopStrategyListProps) => {
                 )}
               </div>
               <div css={cumulativeReturnStyle}>
-                {data.cumulativeProfitLossRate !== 0 ? (
+                {data.cumulativeProfitLossRateList.length > 0 ? (
                   <>
-                    <span className='value'>{formatRate(data.cumulativeProfitLossRate)}</span>
+                    <span className='value'>
+                      {data.cumulativeProfitLossRateList[
+                        data.cumulativeProfitLossRateList.length - 1
+                      ].toFixed(2)}
+                    </span>
                     <span className='percent'>%</span>
                   </>
                 ) : (

--- a/src/components/page/home/TopStrategyList.tsx
+++ b/src/components/page/home/TopStrategyList.tsx
@@ -76,9 +76,11 @@ const TopStrategyList = ({ rankingData }: TopStrategyListProps) => {
                 {data.cumulativeProfitLossRateList.length > 0 ? (
                   <>
                     <span className='value'>
-                      {data.cumulativeProfitLossRateList[
-                        data.cumulativeProfitLossRateList.length - 1
-                      ].toFixed(2)}
+                      {formatRate(
+                        data.cumulativeProfitLossRateList[
+                          data.cumulativeProfitLossRateList.length - 1
+                        ]
+                      )}
                     </span>
                     <span className='percent'>%</span>
                   </>
@@ -119,14 +121,14 @@ const headerStyle = css`
   color: ${theme.colors.main.white};
   display: grid;
   height: 56px;
-  grid-template-columns: 64px 378px 378px 160px 160px;
+  grid-template-columns: 64px 310px 310px 228px 228px;
   align-items: center;
   text-align: center;
 `;
 
 const rowStyle = css`
   display: grid;
-  grid-template-columns: 64px 378px 378px 160px 160px;
+  grid-template-columns: 64px 310px 310px 228px 228px;
   height: 200px;
   align-items: center;
   text-align: center;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

[feat] 메인페이지 SMScore Top5 api명세서 따로 만들어주셔서 재api 연결 (#325)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

[feat] 메인페이지 SMScore Top5 api명세서 따로 만들어주셔서 재api 연결 (#325)
- 누적수익률은 format 함수 어떻게 써야하는지 모르고, `.toFixed(2)}` 이걸로 적용했습니다. 

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/3c99271e-d20c-469a-b28d-25fbf3a056cf)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

메인 페이지를 새로운 API 엔드포인트에 연결하여 상위 5개의 SMScore 전략을 가져오고, 데이터 구조와 구성 요소 로직을 이에 맞게 업데이트합니다.

새로운 기능:
- 메인 페이지에서 상위 5개의 SMScore 전략을 가져오는 새로운 API 엔드포인트 도입.

개선 사항:
- 속성 이름과 데이터 처리 변경을 포함하여 업데이트된 API 데이터 구조를 사용하도록 TopStrategyList 구성 요소 리팩토링.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Connect the main page to a new API endpoint for fetching the top 5 SMScore strategies, updating the data structure and component logic accordingly.

New Features:
- Introduce a new API endpoint for fetching the top 5 SMScore strategies on the main page.

Enhancements:
- Refactor the TopStrategyList component to use updated API data structure, including changes to property names and data handling.

</details>