### PR TITLE
[Fix] 전략 상세 페이지 통계탭 단위 처리 및 비회원 블러 처리

### DIFF
--- a/src/api/stockType.ts
+++ b/src/api/stockType.ts
@@ -58,13 +58,11 @@ export const fetchDeleteInvestmentType = async (id: number, role: UserRole, file
 export const fetchPostInvestmentType = async ({
   investmentAssetClassesName,
   investmentAssetClassesIcon,
-  isActive,
   role,
 }: InvestmentAssetProps & { role: UserRole }) => {
   const body = {
     investmentAssetClassesName,
     investmentAssetClassesIcon,
-    isActive,
   };
   try {
     const req = await apiClient.post(`${API_ENDPOINTS.ADMIN.STOCK_TYPES}`, body, {
@@ -84,14 +82,12 @@ export const fetchPutInvestmentType = async ({
   order,
   investmentAssetClassesName,
   investmentAssetClassesIcon,
-  isActive,
   role,
 }: InvestmentAssetProps & { role: UserRole }) => {
   const body = {
     order,
     investmentAssetClassesName,
     investmentAssetClassesIcon,
-    isActive,
     role,
   };
   try {

--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -12,15 +12,14 @@ import {
 } from '@/types/strategyDetail';
 
 //전략 상세 기본 정보 조회
-export const fetchDefaultStrategyDetail = async (id: number) => {
+export const fetchDefaultStrategyDetail = async (id: number, role: UserRole) => {
   if (!id) {
     throw new Error('Strategy ID is required');
   }
   try {
     const res = await apiClient.get(`${API_ENDPOINTS.STRATEGY.CREATE}/${id}`, {
       headers: {
-        'Content-Type': 'application/json',
-        Auth: 'admin',
+        Auth: role,
       },
     });
     return res.data;
@@ -30,12 +29,11 @@ export const fetchDefaultStrategyDetail = async (id: number) => {
 };
 
 //전략 상세 기본 정보 삭제
-export const fetchDeleteStrategyDetail = async (id: number) => {
+export const fetchDeleteStrategyDetail = async (id: number, role: UserRole) => {
   try {
     const req = await apiClient.delete(`${API_ENDPOINTS.STRATEGY.CREATE}/${id}`, {
       headers: {
-        'Content-Type': 'application/json',
-        Auth: 'admin',
+        Auth: role,
       },
     });
     return req.data;
@@ -45,7 +43,12 @@ export const fetchDeleteStrategyDetail = async (id: number) => {
 };
 
 //일간분석 조회
-export const fetchDailyAnalysis = async (strategyId: number, page: number, pageSize: number) => {
+export const fetchDailyAnalysis = async (
+  strategyId: number,
+  page: number,
+  pageSize: number,
+  role: UserRole
+) => {
   try {
     const res = await apiClient.get(
       `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/daily-analyses`,
@@ -55,7 +58,7 @@ export const fetchDailyAnalysis = async (strategyId: number, page: number, pageS
           pageSize,
         },
         headers: {
-          auth: 'admin',
+          auth: role,
         },
       }
     );
@@ -66,7 +69,7 @@ export const fetchDailyAnalysis = async (strategyId: number, page: number, pageS
 };
 
 //전략 엑셀 등록
-export const fetchUploadExcel = async (strategyId: number, fileItem: File, authRole: UserRole) => {
+export const fetchUploadExcel = async (strategyId: number, fileItem: File, role: UserRole) => {
   const formData = createFormDataRequest({ file: fileItem });
   try {
     const req = await apiClient.post(
@@ -74,7 +77,7 @@ export const fetchUploadExcel = async (strategyId: number, fileItem: File, authR
       formData,
       {
         headers: {
-          auth: authRole,
+          auth: role,
         },
       }
     );
@@ -90,7 +93,7 @@ export const fetchUploadExcel = async (strategyId: number, fileItem: File, authR
 export const fetchPostDailyAnalysis = async (
   strategyId: number,
   { payload }: InputDailyAnalysisProps,
-  authRole: 'admin' | 'trader'
+  role: UserRole
 ) => {
   const body = { payload };
   try {
@@ -99,7 +102,7 @@ export const fetchPostDailyAnalysis = async (
       body,
       {
         headers: {
-          Auth: authRole,
+          Auth: role,
         },
       }
     );
@@ -114,7 +117,7 @@ export const fetchPostDailyAnalysis = async (
 export const fetchPutDailyAnalysis = async (
   strategyId: number,
   payload: DailyAnalysisProps,
-  authRole: 'admin' | 'trader',
+  role: UserRole,
   dailyDataId: number
 ) => {
   const body = payload;
@@ -124,7 +127,7 @@ export const fetchPutDailyAnalysis = async (
       body,
       {
         headers: {
-          Auth: authRole,
+          Auth: role,
         },
       }
     );
@@ -159,7 +162,12 @@ export const fetchDeleteDailyAnalysis = async (
 };
 
 //월간분석 조회
-export const fetchMonthlyAnalysis = async (strategyId: number, page: number, pageSize: number) => {
+export const fetchMonthlyAnalysis = async (
+  strategyId: number,
+  page: number,
+  pageSize: number,
+  role: UserRole
+) => {
   try {
     const res = await apiClient.get(
       `${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/monthly-analysis`,
@@ -169,7 +177,7 @@ export const fetchMonthlyAnalysis = async (strategyId: number, page: number, pag
           pageSize,
         },
         headers: {
-          auth: 'admin',
+          auth: role,
         },
       }
     );
@@ -180,11 +188,11 @@ export const fetchMonthlyAnalysis = async (strategyId: number, page: number, pag
 };
 
 //전략 상세 통계 조회
-export const fetchStatistics = async (strategyId: number) => {
+export const fetchStatistics = async (strategyId: number, role: UserRole) => {
   try {
     const res = await apiClient.get(`${API_ENDPOINTS.STRATEGY.CREATE}/${strategyId}/statistics`, {
       headers: {
-        auth: 'admin',
+        auth: role,
       },
     });
     return res.data;

--- a/src/api/tradingType.ts
+++ b/src/api/tradingType.ts
@@ -41,7 +41,7 @@ export const fetchTradingTypeDetail = async (id: number, role: string | null) =>
 export const fetchDeleteTradingType = async (id: number, role: string | null, fileUrl: string) => {
   try {
     if (fileUrl) {
-      await fetchDeleteIcon(role, decodeURIComponent(fileUrl));
+      await fetchDeleteIcon(role, fileUrl);
     }
     const req = await apiClient.delete(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${id}`, {
       headers: {
@@ -59,13 +59,12 @@ export const fetchDeleteTradingType = async (id: number, role: string | null, fi
 export const fetchPostTradingType = async ({
   tradingTypeName,
   tradingTypeIcon,
-  isActive,
   role,
 }: TradingTypeProps & { role: UserRole }): Promise<{ msg: string; timestamp: string }> => {
   const body = {
     tradingTypeName,
     tradingTypeIcon,
-    isActive,
+    isActive: 'Y',
   };
 
   const req = await apiClient.post(API_ENDPOINTS.ADMIN.TRADING_TYPES, body, {
@@ -82,14 +81,13 @@ export const fetchPutTradingType = async ({
   tradingTypeOrder,
   tradingTypeName,
   tradingTypeIcon,
-  isActive,
   role,
 }: TradingTypeProps & { role: UserRole }): Promise<{ msg: string; timestamp: string }> => {
   const body = {
     tradingTypeName,
     tradingTypeOrder,
     tradingTypeIcon,
-    isActive,
+    isActive: 'Y',
   };
   const req = await apiClient.put(`${API_ENDPOINTS.ADMIN.TRADING_TYPES}/${tradingTypeId}`, body, {
     headers: {

--- a/src/components/common/LineChart.tsx
+++ b/src/components/common/LineChart.tsx
@@ -44,6 +44,9 @@ const LineChart = ({ data, size, colorTheme }: LineChartProps) => {
       height: sizes[size].height,
       backgroundColor: 'transparent',
     },
+    accessibility: {
+      enabled: false,
+    },
     title: {
       text: '',
     },

--- a/src/components/common/StrategyChart.tsx
+++ b/src/components/common/StrategyChart.tsx
@@ -74,15 +74,26 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
         marker: {
           enabled: false,
         },
+        states: {
+          inactive: {
+            opacity: 0.2,
+          },
+        },
       },
       area: {
         marker: {
           enabled: false,
         },
+        states: {
+          hover: {
+            enabled: true,
+            brightness: 0.8,
+          },
+        },
       },
     },
     series: [
-      ...areaData.map((dataItem) => ({
+      ...areaData.map((dataItem, idx) => ({
         type: 'areaspline',
         name: dataItem.label,
         data: dataItem.data,
@@ -94,14 +105,20 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
             x2: 0,
             y2: 1,
           },
-          stops: [
-            [1, colors.primary.middleColor],
-            [1, colors.primary.fillColor],
-            [1, theme.colors.main.white],
-          ],
+          stops:
+            idx === 0
+              ? [
+                  [0, colors.primary.middleColor],
+                  [1, colors.primary.fillColor],
+                ]
+              : [
+                  [0, colors.primary.lineColor],
+                  [1, colors.primary.fillColor],
+                ],
         },
+        fillOpacity: 0.7,
         states: {
-          hover: { enabled: false },
+          hover: { enabled: true },
         },
         tooltip: {
           pointFormat: `
@@ -125,8 +142,7 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
       })),
     ],
     tooltip: {
-      shared: true,
-      useHTML: true,
+      shared: false,
     },
   };
 

--- a/src/components/common/StrategyChart.tsx
+++ b/src/components/common/StrategyChart.tsx
@@ -34,6 +34,9 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
       backgroundColor: 'transparent',
       width: 900,
     },
+    accessibility: {
+      enabled: false,
+    },
     title: {
       text: '',
     },

--- a/src/components/page/strategy-detail/ReasonItem.tsx
+++ b/src/components/page/strategy-detail/ReasonItem.tsx
@@ -4,20 +4,20 @@ import theme from '@/styles/theme';
 
 interface RejectReasonProps {
   title: string;
-  admin: string;
-  adminImg: string;
-  content: string;
+  managerNickname: string;
+  profileImg: string;
+  rejectionReason: string;
 }
-const ReasonItem = ({ title, admin, adminImg, content }: RejectReasonProps) => (
+const ReasonItem = ({ title, managerNickname, profileImg, rejectionReason }: RejectReasonProps) => (
   <div css={reasonStyle}>
     <div css={headerStyle}>
       <div css={titleStyle}>{title}</div>
       <div css={adminStyle}>
-        <img src={adminImg} alt={admin} css={imgStyle} />
-        <div>{admin}</div>
+        <img src={profileImg} alt={managerNickname} css={imgStyle} />
+        <div>{managerNickname}</div>
       </div>
     </div>
-    <div css={contentStyle}>{content}</div>
+    <div css={contentStyle}>{rejectionReason}</div>
   </div>
 );
 

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -11,6 +11,7 @@ import ContentModal from '@/components/common/ContentModal';
 import Toast from '@/components/common/Toast';
 import FollowModal from '@/components/page/mypage-investor/myfolder/FollowModal';
 import { ROUTES } from '@/constants/routes';
+import { useToastWithNavigate } from '@/hooks/useToastWithNavigate';
 import { useAuthStore } from '@/stores/authStore';
 import useContentModalStore from '@/stores/contentModalStore';
 import useToastStore from '@/stores/toastStore';
@@ -46,7 +47,8 @@ export const StrategyHeader = ({
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useAuthStore();
-  const userRole = user?.role as UserRole; // 유저 지정
+  const showToastAndNavigate = useToastWithNavigate();
+  const userRole = user?.role as UserRole;
   const { showToast, type, message, hideToast, isToastVisible } = useToastStore();
   const { openContentModal } = useContentModalStore();
 
@@ -65,6 +67,10 @@ export const StrategyHeader = ({
   };
 
   const handleFollowingPage = () => {
+    if (!user) {
+      showToastAndNavigate('로그인이 필요한 서비스 입니다.', ROUTES.AUTH.SIGNIN, 'error');
+      return;
+    }
     let selectedFolderId = '';
 
     openContentModal({

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -108,8 +108,8 @@ const AnalysisTable = ({
         </thead>
         <tbody>
           {analysis?.length || 0 ? (
-            analysis?.map((values) => (
-              <tr key={values.dataId} css={tableRowStyle}>
+            analysis?.map((values, idx) => (
+              <tr key={`${values.dataId}- ${idx}`} css={tableRowStyle}>
                 {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
                 role === 'ROLE_ADMIN' ? (
                   <td css={tableCellStyle}>

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -25,7 +25,6 @@ interface AccountProps {
   strategyId: number;
   role?: UserRole;
   userId: string;
-  isSelfed: boolean;
 }
 
 interface AccountImgProps {
@@ -34,7 +33,7 @@ interface AccountImgProps {
   fileLink: string;
 }
 
-const AccountVerify = ({ strategyId, isSelfed, role, userId }: AccountProps) => {
+const AccountVerify = ({ strategyId, role, userId }: AccountProps) => {
   const { user } = useAuthStore();
   const { pagination, setPage } = usePagination(1, 8);
   const { accountImgs, page, pageSize, totalPages, isLoading } = useFetchAccountImg(
@@ -49,6 +48,7 @@ const AccountVerify = ({ strategyId, isSelfed, role, userId }: AccountProps) => 
   const { openModal } = useModalStore();
   const { showToast, message, hideToast, isToastVisible } = useToastStore();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const isSelfed = (role === 'ROLE_TRADER' && userId === user?.memberId) || role === 'ROLE_ADMIN';
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
@@ -113,7 +113,7 @@ const AccountVerify = ({ strategyId, isSelfed, role, userId }: AccountProps) => 
 
   return (
     <div css={accountWrapper}>
-      {isSelfed && userId === user?.memberId && (
+      {isSelfed && (
         <div css={headingStyle}>
           <div css={textStyle}>
             <MdCheck css={iconStyle} size={24} />

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -42,7 +42,8 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
   const { dailyAnalysis, currentPage, pageSize, totalPages, isLoading } = useFetchDailyAnalysis(
     Number(strategyId),
     pagination.currentPage - 1,
-    pagination.pageSize
+    pagination.pageSize,
+    role as UserRole
   );
 
   const normalizedData = useMemo(() => {

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -141,7 +141,7 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
     postDailyAnalysis({
       strategyId: Number(strategyId),
       payload,
-      authRole: 'admin',
+      authRole: role as UserRole,
     });
 
     modalData = [];
@@ -192,7 +192,7 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
         putDailyAnalysis({
           strategyId,
           payload: updatedData,
-          authRole: 'admin',
+          authRole: role as UserRole,
           dailyDataId: rowId,
         });
         updatedData = null;

--- a/src/components/page/strategy-detail/tabmenu/MonthlyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/MonthlyAnalysis.tsx
@@ -7,6 +7,7 @@ import AnalysisTable, { AnalysisProps } from '../table/AnalysisTable';
 import Pagination from '@/components/common/Pagination';
 import useFetchMonthlyAnalysis from '@/hooks/queries/useFetchMonthlyAnalysis';
 import usePagination from '@/hooks/usePagination';
+import { UserRole } from '@/types/route';
 
 export interface MonthlyDataProps {
   strategyMonthlyDataId: number;
@@ -19,12 +20,13 @@ export interface MonthlyDataProps {
   monthlyCumulativeReturn: number;
 }
 
-const MonthlyAnalysis = ({ attributes, strategyId }: AnalysisProps) => {
+const MonthlyAnalysis = ({ attributes, strategyId, role }: AnalysisProps) => {
   const { pagination, setPage } = usePagination(1, 5);
   const { monthlyAnalysis, currentPage, pageSize, totalPages, isLoading } = useFetchMonthlyAnalysis(
     Number(strategyId),
     pagination.currentPage - 1,
-    pagination.pageSize
+    pagination.pageSize,
+    role as UserRole
   );
 
   const normalizedData = useMemo(() => {

--- a/src/hooks/mutations/useDailyAnalysis.ts
+++ b/src/hooks/mutations/useDailyAnalysis.ts
@@ -20,7 +20,7 @@ export const usePostDailyAnalysis = () => {
     }: {
       strategyId: number;
       payload: DailyAnalysisProps[];
-      authRole: 'admin' | 'trader';
+      authRole: UserRole;
     }) => fetchPostDailyAnalysis(strategyId, { payload }, authRole),
     onError: (error) => error.message,
     onSuccess: () => {
@@ -43,7 +43,7 @@ export const usePutDailyAnalysis = () => {
     }: {
       strategyId: number;
       payload: DailyAnalysisProps;
-      authRole: 'admin' | 'trader';
+      authRole: UserRole;
       dailyDataId: number;
     }) => fetchPutDailyAnalysis(strategyId, payload, authRole, dailyDataId),
     onError: (error) => error.message,

--- a/src/hooks/mutations/useStrategyDetailMutation.ts
+++ b/src/hooks/mutations/useStrategyDetailMutation.ts
@@ -10,8 +10,9 @@ import { UserRole } from '@/types/route';
 export const useStrategyDetailDelete = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<{ msg: string }, Error, number>({
-    mutationFn: (data: number) => fetchDeleteStrategyDetail(data),
+  return useMutation({
+    mutationFn: ({ id, role }: { id: number; role: UserRole }) =>
+      fetchDeleteStrategyDetail(id, role),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['strategyDetail'] });
     },

--- a/src/hooks/queries/useFetchDailyAnalysis.ts
+++ b/src/hooks/queries/useFetchDailyAnalysis.ts
@@ -1,12 +1,18 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { fetchDailyAnalysis } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
 
-const useFetchDailyAnalysis = (strategyId: number, page: number, pageSize: number) => {
+const useFetchDailyAnalysis = (
+  strategyId: number,
+  page: number,
+  pageSize: number,
+  role: UserRole
+) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['dailyAnalysis', strategyId, page, pageSize],
+    queryKey: ['dailyAnalysis', strategyId, page, pageSize, role],
     queryFn: async () => {
-      const res = await fetchDailyAnalysis(strategyId, page, pageSize);
+      const res = await fetchDailyAnalysis(strategyId, page, pageSize, role);
       if (!strategyId) {
         throw new Error('Invalid DailyAnalysis');
       }

--- a/src/hooks/queries/useFetchMonthlyAnalysis.ts
+++ b/src/hooks/queries/useFetchMonthlyAnalysis.ts
@@ -1,12 +1,18 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { fetchMonthlyAnalysis } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
 
-const useFetchMonthlyAnalysis = (strategyId: number, page: number, pageSize: number) => {
+const useFetchMonthlyAnalysis = (
+  strategyId: number,
+  page: number,
+  pageSize: number,
+  role: UserRole
+) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['monthlyAnalysis', strategyId, page, pageSize],
+    queryKey: ['monthlyAnalysis', strategyId, page, pageSize, role],
     queryFn: async () => {
-      const res = await fetchMonthlyAnalysis(strategyId, page, pageSize);
+      const res = await fetchMonthlyAnalysis(strategyId, page, pageSize, role);
       if (!strategyId) {
         throw new Error('Invalid monthlyAnalysis');
       }

--- a/src/hooks/queries/useFetchStrategyDetail.ts
+++ b/src/hooks/queries/useFetchStrategyDetail.ts
@@ -1,12 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchDefaultStrategyDetail } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
 
-const useFetchStrategyDetail = (strategyId: string) => {
+const useFetchStrategyDetail = (strategyId: string, role: UserRole) => {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['strategyDetail', strategyId],
+    queryKey: ['strategyDetail', strategyId, role],
     queryFn: async () => {
-      const res = await fetchDefaultStrategyDetail(Number(strategyId));
+      const res = await fetchDefaultStrategyDetail(Number(strategyId), role);
       if (!res.data || !res.data.strategyTitle) {
         throw new Error('Invalid strategy data');
       }

--- a/src/hooks/queries/useStatistics.ts
+++ b/src/hooks/queries/useStatistics.ts
@@ -1,12 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchStatistics } from '@/api/strategyDetail';
+import { UserRole } from '@/types/route';
 
-const useStatistics = (strategyId: number) => {
+const useStatistics = (strategyId: number, role: UserRole) => {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['strategyStatistics', strategyId],
+    queryKey: ['strategyStatistics', strategyId, role],
     queryFn: async () => {
-      const res = await fetchStatistics(strategyId);
+      const res = await fetchStatistics(strategyId, role);
       return {
         statistics: res.data,
         writedAt: res.timestamp,

--- a/src/pages/admin/stock-type/StockTypeListPage.tsx
+++ b/src/pages/admin/stock-type/StockTypeListPage.tsx
@@ -155,7 +155,6 @@ const StockTypeListPage = () => {
           data: {
             investmentAssetClassesName: newName,
             investmentAssetClassesIcon: selectedIcon,
-            isActive: 'Y',
           },
           role: user.role,
         });
@@ -209,7 +208,6 @@ const StockTypeListPage = () => {
                   investmentAssetClassesId: investmentDetail.investmentAssetClassesId,
                   investmentAssetClassesName: updatedName,
                   investmentAssetClassesIcon: updatedIcon,
-                  isActive: 'Y',
                 },
                 role: user.role,
               });

--- a/src/pages/admin/trading-type/TradingTypeListPage.tsx
+++ b/src/pages/admin/trading-type/TradingTypeListPage.tsx
@@ -159,7 +159,6 @@ const TradingTypeListPage = () => {
           data: {
             tradingTypeName: newName,
             tradingTypeIcon: newIcon,
-            isActive: 'Y',
           },
           role: user.role,
         });
@@ -171,7 +170,6 @@ const TradingTypeListPage = () => {
 
   useEffect(() => {
     if (!user || !tradingId) return;
-    console.log('tradingDetailtradingDetail', tradingDetail);
     const fetchAndOpenModal = async () => {
       try {
         const { data } = await refetch();
@@ -204,7 +202,6 @@ const TradingTypeListPage = () => {
                   tradingTypeOrder: tradingDetail.tradingTypeOrder,
                   tradingTypeName: updatedName,
                   tradingTypeIcon: updatedIcon,
-                  isActive: 'Y',
                 },
                 role: user.role,
               });

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -47,13 +47,13 @@ const StrategyDetailPage = () => {
   const { strategyId } = useParams();
   const navigate = useNavigate();
   const role = user?.role as UserRole;
-  const { strategy } = useFetchStrategyDetail(strategyId || '');
+  const { strategy } = useFetchStrategyDetail(strategyId || '', role);
   const { statistics } = useStatistics(Number(strategyId), role);
   const { mutate: deleteStrategyDetail } = useStrategyDetailDelete();
   const { mutate: approveStrategy } = useStrategyDetailApprove();
   const { mutate: terminateStrategy } = useStrategyDetailTerminate();
   const { openModal } = useModalStore();
-  const { dailyAnalysis } = useFetchDailyAnalysis(Number(strategyId), 0, 5);
+  const { dailyAnalysis } = useFetchDailyAnalysis(Number(strategyId), 0, 5, role);
   const { data: approveState } =
     useFetchApproveState(Number(strategyId), role, {
       enabled: strategy?.isApproved === 'N',

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -314,7 +314,7 @@ const blurText = css`
 
 const blurArea = css`
   position: absolute;
-  top: 40%;
+  top: 50%;
   left: 0;
   width: 100%;
   height: 100%;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -47,7 +47,7 @@ const StrategyDetailPage = () => {
   const navigate = useNavigate();
   const role = user?.role as UserRole;
   const { strategy } = useFetchStrategyDetail(strategyId || '');
-  const { statistics, writedAt } = useStatistics(Number(strategyId));
+  const { statistics, writedAt } = useStatistics(Number(strategyId), role);
   const { mutate: deleteStrategyDetail } = useStrategyDetailDelete();
   const { mutate: approveStrategy } = useStrategyDetailApprove();
   const { mutate: terminateStrategy } = useStrategyDetailTerminate();
@@ -136,7 +136,7 @@ const StrategyDetailPage = () => {
       title: '전략 삭제',
       desc: '해당 전략의 모든 정보가 삭제됩니다.',
       onAction: () => {
-        deleteStrategyDetail(id);
+        deleteStrategyDetail({ id, role });
         navigate(ROUTES.STRATEGY.LIST);
       },
     });
@@ -187,12 +187,7 @@ const StrategyDetailPage = () => {
         strategy?.isApproved !== 'P' &&
         approveState?.isApproved === 'N' &&
         strategy?.isApproved === 'N' && (
-          <ReasonItem
-            title='미승인 이유는 이렇습니다'
-            content={approveState?.rejectionReason}
-            admin={approveState?.managerNickname}
-            adminImg={approveState?.profileImg}
-          />
+          <ReasonItem title='미승인 이유는 이렇습니다' {...approveState} />
         )}
       <div css={contentStyle}>
         <div css={contentWrapper}>

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -234,15 +234,17 @@ const StrategyDetailPage = () => {
             </div>
             {!isLoggedin && (
               <div css={blurArea}>
-                <p css={blurText}>로그인 및 회원가입 후 더 많은 전략들을 만나보세요</p>
-                <div css={userButtonStyle}>
-                  {' '}
-                  <Button width={150} onClick={handleMoveLogin}>
-                    로그인 하러가기
-                  </Button>
-                  <Button width={150} onClick={handleMoveSignIn}>
-                    회원가입 하러가기
-                  </Button>
+                <div css={blurContent}>
+                  <p css={blurText}>로그인 및 회원가입 후 더 많은 전략들을 만나보세요</p>
+                  <div css={userButtonStyle}>
+                    {' '}
+                    <Button width={150} onClick={handleMoveLogin}>
+                      로그인 하러가기
+                    </Button>
+                    <Button width={150} onClick={handleMoveSignIn}>
+                      회원가입 하러가기
+                    </Button>
+                  </div>
                 </div>
               </div>
             )}
@@ -307,26 +309,35 @@ const bluerredContent = css`
   pointer-events: none;
 `;
 
-const blurText = css`
-  ${theme.textStyle.subtitles.subtitle3};
-  margin-bottom: 40px;
-`;
-
-const blurArea = css`
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 100%;
+const blurContent = css`
   display: flex;
+  position: absolute;
+  margin-bottom: 2500px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+`;
+
+const blurText = css`
+  ${theme.textStyle.subtitles.subtitle1};
+`;
+
+const blurArea = css`
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 10;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const userButtonStyle = css`
   display: flex;
+  margin-top: 30px;
   gap: 10px;
 `;
 

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import Button from '@/components/common/Button';
 import Loader from '@/components/common/Loading';
 import Modal from '@/components/common/Modal';
 import Toast from '@/components/common/Toast';
@@ -62,6 +63,7 @@ const StrategyDetailPage = () => {
   const isTerminated = strategy?.strategyStatusCode === 'STRATEGY_OPERATION_TERMINATED';
   const isOwner = user?.memberId === strategy?.memberId;
   const isAdmin = role === 'ROLE_ADMIN';
+  const isLoggedin = !!role;
 
   const statisticsTableData = (
     mapping: { label: string; key: string }[],
@@ -166,6 +168,14 @@ const StrategyDetailPage = () => {
     });
   };
 
+  const handleMoveLogin = () => {
+    navigate(ROUTES.AUTH.SIGNIN);
+  };
+
+  const handleMoveSignIn = () => {
+    navigate(ROUTES.AUTH.SIGNUP.SELECT_TYPE);
+  };
+
   useEffect(() => {
     if (
       (strategy?.isApproved === 'N' && !(isOwner || isAdmin)) ||
@@ -217,9 +227,25 @@ const StrategyDetailPage = () => {
             />
             <StrategyContent content={strategy?.strategyOverview} />
             {strategy?.strategyProposalLink && <FileDownSection {...strategy} />}
-            <StrategyIndicator {...statistics} />
-            <ChartSection strategyId={Number(strategyId)} role={role} />
-            <StrategyTab tabs={tabMenu} />
+            <div css={!isLoggedin ? bluerredContent : null}>
+              <StrategyIndicator {...statistics} />
+              <ChartSection strategyId={Number(strategyId)} role={role} />
+              <StrategyTab tabs={tabMenu} />
+            </div>
+            {!isLoggedin && (
+              <div css={blurArea}>
+                <p css={blurText}>로그인 및 회원가입 후 더 많은 전략들을 만나보세요</p>
+                <div css={userButtonStyle}>
+                  {' '}
+                  <Button width={150} onClick={handleMoveLogin}>
+                    로그인 하러가기
+                  </Button>
+                  <Button width={150} onClick={handleMoveSignIn}>
+                    회원가입 하러가기
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -274,6 +300,34 @@ const noneStaticsStyle = css`
 const reviewSectionWrapper = css`
   width: ${theme.layout.width.content};
   margin: 16px 0 76px 0;
+`;
+
+const bluerredContent = css`
+  filter: blur(30px);
+  pointer-events: none;
+`;
+
+const blurText = css`
+  ${theme.textStyle.subtitles.subtitle3};
+  margin-bottom: 40px;
+`;
+
+const blurArea = css`
+  position: absolute;
+  top: 40%;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+`;
+
+const userButtonStyle = css`
+  display: flex;
+  gap: 10px;
 `;
 
 export default StrategyDetailPage;

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -47,7 +47,7 @@ const StrategyDetailPage = () => {
   const navigate = useNavigate();
   const role = user?.role as UserRole;
   const { strategy } = useFetchStrategyDetail(strategyId || '');
-  const { statistics, writedAt } = useStatistics(Number(strategyId), role);
+  const { statistics } = useStatistics(Number(strategyId), role);
   const { mutate: deleteStrategyDetail } = useStrategyDetailDelete();
   const { mutate: approveStrategy } = useStrategyDetailApprove();
   const { mutate: terminateStrategy } = useStrategyDetailTerminate();
@@ -62,7 +62,6 @@ const StrategyDetailPage = () => {
   const isTerminated = strategy?.strategyStatusCode === 'STRATEGY_OPERATION_TERMINATED';
   const isOwner = user?.memberId === strategy?.memberId;
   const isAdmin = role === 'ROLE_ADMIN';
-  const isPrivate = role === 'ROLE_ADMIN' || role === 'ROLE_TRADER';
 
   const statisticsTableData = (
     mapping: { label: string; key: string }[],
@@ -93,7 +92,6 @@ const StrategyDetailPage = () => {
           strategyId={Number(strategyId)}
           userId={strategy?.memberId}
           role={user?.role}
-          isSelfed={isPrivate}
         />
       ),
     },
@@ -215,7 +213,7 @@ const StrategyDetailPage = () => {
               date={formatDate(strategy?.writedAt || '', 'withDayTime')}
               followers={strategy?.followersCount}
               minimumInvestment={strategy?.minInvestmentAmount}
-              lastUpdatedDate={writedAt ? formatDate(writedAt) : '데이터없음'}
+              lastUpdatedDate={statistics?.endDate ? formatDate(statistics?.endDate) : '데이터없음'}
             />
             <StrategyContent content={strategy?.strategyOverview} />
             {strategy?.strategyProposalLink && <FileDownSection {...strategy} />}

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -3,7 +3,6 @@ export interface TradingTypeProps {
   tradingTypeOrder?: number;
   tradingTypeName: string;
   tradingTypeIcon: string;
-  isActive?: string;
 }
 
 export interface InvestmentAssetProps {
@@ -11,5 +10,4 @@ export interface InvestmentAssetProps {
   order?: number;
   investmentAssetClassesName: string;
   investmentAssetClassesIcon: string;
-  isActive: string;
 }

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -1,15 +1,5 @@
 //10000 -> 10,000
-export const formatLoss = (value: number) => {
-  const absValue = Math.abs(value);
-  const op = value < 0 ? '-' : '';
-  if (absValue >= 100000000) {
-    return `${op}${Math.floor(absValue / 100000000)}억`;
-  } else if (absValue >= 10000000) {
-    return `${op}${Math.floor(absValue / 10000)}만`;
-  } else {
-    return `${op}${absValue.toLocaleString()}`;
-  }
-};
+export const formatLoss = (value: number) => value.toLocaleString();
 
 //23.23223 -> 23.23
 export const formatRate = (value: number) => Math.floor(value * 100) / 100;

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -2,7 +2,7 @@
 export const formatLoss = (value: number) => value.toLocaleString();
 
 //23.23223 -> 23.23
-export const formatRate = (value: number) => Math.round(value * 100) / 100;
+export const formatRate = (value: number) => Math.floor(value * 100) / 100;
 
 export const formatValue = (key: string, value: string | number) => {
   if (typeof value === 'number') {

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -1,13 +1,37 @@
 //10000 -> 10,000
-export const formatLoss = (value: number) => value.toLocaleString();
+export const formatLoss = (value: number) => {
+  const absValue = Math.abs(value);
+  const op = value < 0 ? '-' : '';
+  if (absValue >= 100000000) {
+    return `${op}${Math.floor(absValue / 100000000)}억`;
+  } else if (absValue >= 10000000) {
+    return `${op}${Math.floor(absValue / 10000)}만`;
+  } else {
+    return `${op}${absValue.toLocaleString()}`;
+  }
+};
 
 //23.23223 -> 23.23
 export const formatRate = (value: number) => Math.floor(value * 100) / 100;
 
 export const formatValue = (key: string, value: string | number) => {
   if (typeof value === 'number') {
-    if (key.endsWith('Rate') || key.endsWith('Ratio')) {
-      return Math.round(value * 100) / 100 + '%';
+    if (
+      key.endsWith('Rate') ||
+      key.endsWith('Ratio') ||
+      key.endsWith('roa') ||
+      key.endsWith('Factor')
+    ) {
+      return Math.floor(value * 100) / 100 + '%';
+    } else if (key.endsWith('Days') || key.endsWith('Period') || key.endsWith('Peak')) {
+      const years = Math.floor(value / 365);
+      const month = Math.floor((value % 365) / 30);
+      const days = (value % 365) % 30;
+      let result = '';
+      if (years > 0) result += `${years}년 `;
+      if (month > 0) result += `${month}개월 `;
+      if (days >= 0 || days <= 0) result += `${days}일`;
+      return result.trim();
     } else {
       return formatLoss(value);
     }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

통계탭에서 자산은 그대로 1원 단위까지 나오도록 뒀고 기간, 확률은 단위가 붙도록 수정했습니다.
관리자 페이지 투자자산분류 isActive 삭제했습니다.
차트 관련 경고가 떠서 그 부분 해결했습니다.
비회원이 전략 상세 페이지에 접속 후 상단의 팔로우 버튼을 클릭할 시 로그인이 필요한 서비스라는 토스트 알림이 뜨고 
로그인 화면으로 리다이렉트 되도록 처리했습니다.
비회원은 전략 상세 페이지에 접속 후 제안서 이후로는 블러처리 되어서 보이도록 추가했으며 로그인 버튼, 회원가입 버튼 클릭 시
해당 페이지로 이동하도록 처리했습니다.

서버에서 아직 비로그인한 사용자는 전략 상세 페이지를 못보도록 막아둔 상태라 해제 후 다시 배포하면 PR 다시 열도록 하겠습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

전략 세부 페이지를 업데이트하여 통계 탭에서 단위 표시를 처리하고 비회원의 콘텐츠를 흐리게 처리합니다. 차트 관련 경고를 수정하고 관리자 페이지의 투자 자산 분류에서 'isActive' 속성을 제거합니다. 비회원이 특정 기능에 접근할 때 로그인 또는 회원가입을 하도록 안내합니다.

버그 수정:
- 전략 세부 페이지의 차트 관련 경고 수정.

개선 사항:
- 로그인하지 않은 사용자를 위해 전략 세부 페이지의 콘텐츠를 흐리게 처리하고 로그인/회원가입 안내를 제공합니다.
- 관리자 페이지의 투자 자산 분류에서 'isActive' 속성을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the strategy detail page to handle unit display in the statistics tab and blur content for non-members. Fix chart-related warnings and remove the 'isActive' property from the admin page's investment asset classification. Ensure non-members are prompted to log in or sign up when accessing certain features.

Bug Fixes:
- Fix chart-related warnings in the strategy detail page.

Enhancements:
- Enhance the strategy detail page to blur content for non-logged-in users and provide login/signup prompts.
- Remove the 'isActive' property from the admin page's investment asset classification.

</details>