### PR TITLE
[Feat] 관심 전략 내부 폴더 이동 API 연동 

### DIFF
--- a/src/api/follow.ts
+++ b/src/api/follow.ts
@@ -40,3 +40,21 @@ export const fetchFollowingList = async (
     throw error;
   }
 };
+
+// 관심 전략 폴더 이동
+export const updateFollowingFolder = async ({
+  strategyId,
+  folderId,
+}: {
+  strategyId: number;
+  folderId: number;
+}) => {
+  try {
+    return await apiClient.put(
+      `${API_ENDPOINTS.FOLLOWING.STRATEGY}/${strategyId}/folder/${folderId}`
+    );
+  } catch (error) {
+    console.error('Failed to update folder name:', error);
+    throw error;
+  }
+};

--- a/src/components/page/mypage-investor/myfolder/FolderModal.tsx
+++ b/src/components/page/mypage-investor/myfolder/FolderModal.tsx
@@ -12,11 +12,13 @@ import theme from '@/styles/theme';
 const FolderModal = ({
   isMove = false,
   initialFolderName = '',
+  folderTitle = '',
   onChangeFolderName,
   onFolderSelect,
 }: {
   isMove?: boolean;
   initialFolderName?: string;
+  folderTitle?: string;
   onChangeFolderName?: (folderName: string) => void;
   onFolderSelect?: (folderId: string) => void;
 }) => {
@@ -61,7 +63,13 @@ const FolderModal = ({
       {isMove ? (
         <>
           <label htmlFor='move-folder'>이동할 폴더</label>
-          <Select id='move-folder' options={folder} onChange={handleChange} width='100%' />
+          <Select
+            id='move-folder'
+            options={folder}
+            defaultLabel={folderTitle}
+            onChange={handleChange}
+            width='100%'
+          />
         </>
       ) : (
         <>

--- a/src/components/page/mypage-investor/myfolder/FolderModal.tsx
+++ b/src/components/page/mypage-investor/myfolder/FolderModal.tsx
@@ -3,25 +3,24 @@ import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import Input from '@/components/common/Input';
-import Select from '@/components/common/Select';
+import Loader from '@/components/common/Loading';
+import Select, { Option } from '@/components/common/Select';
+import { useFolderList } from '@/hooks/queries/useFetchFolderList';
+import { Folder } from '@/pages/mypage/investor/InvestorMyPage';
 import theme from '@/styles/theme';
-
-const folder = [
-  { label: '기본 폴더', value: '1' },
-  { label: '나의 전략 폴더', value: '2' },
-  { label: '크리스마스때 삭제할 폴더', value: '3' },
-  { label: '그냥 그냥 폴더', value: '4' },
-];
 
 const FolderModal = ({
   isMove = false,
   initialFolderName = '',
   onChangeFolderName,
+  onFolderSelect,
 }: {
   isMove?: boolean;
   initialFolderName?: string;
   onChangeFolderName?: (folderName: string) => void;
+  onFolderSelect?: (folderId: string) => void;
 }) => {
+  const { data, isLoading, isError } = useFolderList();
   const [folderName, setFolderName] = useState(initialFolderName);
 
   useEffect(() => {
@@ -34,12 +33,35 @@ const FolderModal = ({
     onChangeFolderName?.(newValue);
   };
 
+  if (isLoading) {
+    return (
+      <div css={contentWrpperStyle}>
+        <Loader />
+      </div>
+    );
+  }
+
+  if (isError || !data || !data.data) {
+    return <div css={contentWrpperStyle}>폴더 데이터를 불러오지 못했습니다.</div>;
+  }
+
+  const folder = data?.data.map((item: Folder) => ({
+    label: item.folderName,
+    value: item.folderId.toString(),
+  }));
+
+  const handleChange = (selectedOption: Option) => {
+    if (selectedOption && onFolderSelect) {
+      onFolderSelect(selectedOption.value);
+    }
+  };
+
   return (
     <div css={contentWrpperStyle}>
       {isMove ? (
         <>
           <label htmlFor='move-folder'>이동할 폴더</label>
-          <Select id='move-folder' options={folder} onChange={() => {}} width='100%' />
+          <Select id='move-folder' options={folder} onChange={handleChange} width='100%' />
         </>
       ) : (
         <>

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -59,7 +59,7 @@ const InvestorFollowFolderPage = () => {
             refetch();
           })
           .catch(() => {
-            showToast('폴더 이동에 실패했습니다.', 'error');
+            showToast('현재 저장된 폴더입니다.', 'error');
           });
 
         return true;

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 import { useParams } from 'react-router-dom';
 
-import { unfollowStrategy } from '@/api/follow';
+import { unfollowStrategy, updateFollowingFolder } from '@/api/follow';
 import ContentModal from '@/components/common/ContentModal';
 import Loader from '@/components/common/Loading';
 import Pagination from '@/components/common/Pagination';
@@ -22,7 +22,7 @@ const InvestorFollowFolderPage = () => {
   const limit = 10;
 
   const { openContentModal } = useContentModalStore();
-  const { isToastVisible, showToast, hideToast, message } = useToastStore();
+  const { isToastVisible, showToast, hideToast, message, type } = useToastStore();
 
   const { data, isLoading, isError, refetch } = useFollowingList(Number(folderId), page - 1, limit);
   const { data: folderList } = useFolderList();
@@ -31,13 +31,37 @@ const InvestorFollowFolderPage = () => {
     .filter((v: Folder) => v.folderId === Number(folderId))
     .map((v: Folder) => v.folderName);
 
-  const handleMoveFolder = () => {
+  const handleMoveFolder = (strategyId: number) => {
+    let selectedFolderId = '';
+
     openContentModal({
       title: '폴더 이동',
-      content: <FolderModal isMove={true} />,
+      content: (
+        <FolderModal
+          isMove={true}
+          onFolderSelect={(folderId) => {
+            selectedFolderId = folderId;
+          }}
+        />
+      ),
       onAction: () => {
-        console.log('폴더 이동');
-        showToast('폴더 이동이 완료되었습니다.');
+        if (!selectedFolderId) {
+          showToast('폴더를 선택해주세요.', 'error');
+          return false;
+        }
+
+        updateFollowingFolder({
+          strategyId,
+          folderId: Number(selectedFolderId),
+        })
+          .then(() => {
+            showToast('폴더 이동이 완료되었습니다.');
+            refetch();
+          })
+          .catch(() => {
+            showToast('폴더 이동에 실패했습니다.', 'error');
+          });
+
         return true;
       },
     });
@@ -56,7 +80,7 @@ const InvestorFollowFolderPage = () => {
   const dropdownActions = (strategyId: number) => [
     {
       label: '폴더 이동',
-      onClick: () => handleMoveFolder(),
+      onClick: () => handleMoveFolder(strategyId),
     },
     {
       label: '전략 언팔로우',
@@ -98,7 +122,9 @@ const InvestorFollowFolderPage = () => {
         </div>
       </div>
       <ContentModal />
-      {isToastVisible && <Toast message={message} onClose={hideToast} isVisible={isToastVisible} />}
+      {isToastVisible && (
+        <Toast message={message} onClose={hideToast} isVisible={isToastVisible} type={type} />
+      )}
     </div>
   );
 };

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -39,6 +39,7 @@ const InvestorFollowFolderPage = () => {
       content: (
         <FolderModal
           isMove={true}
+          folderTitle={folderTitle}
           onFolderSelect={(folderId) => {
             selectedFolderId = folderId;
           }}
@@ -132,6 +133,7 @@ const InvestorFollowFolderPage = () => {
 const myPageWrapperStyle = css`
   width: 955px;
   padding: 48px 40px 80px 40px;
+  min-height: 823px;
   background-color: ${theme.colors.main.white};
   border-radius: 8px;
 `;

--- a/src/pages/mypage/investor/InvestorMyPage.tsx
+++ b/src/pages/mypage/investor/InvestorMyPage.tsx
@@ -166,7 +166,7 @@ const InvestorMyPage = () => {
           onEditFolder={handleUpdateFolder}
           onDeleteFolder={handleDeleteFolder}
         />
-        <Pagination totalPage={5} limit={10} page={1} setPage={() => {}} />
+        <Pagination totalPage={1} limit={10} page={1} setPage={() => {}} />
       </div>
       <ContentModal />
       <Modal />

--- a/src/pages/strategy/StrategyListPage.tsx
+++ b/src/pages/strategy/StrategyListPage.tsx
@@ -13,6 +13,7 @@ import { ROUTES } from '@/constants/routes';
 import useFetchStrategyList from '@/hooks/queries/useFetchStrategyList';
 import useFetchStrategyOptionData from '@/hooks/queries/useFetchStrategyOptionData';
 import { useAuthStore } from '@/stores/authStore';
+import useToastStore from '@/stores/toastStore';
 import theme from '@/styles/theme';
 
 const desc = [
@@ -31,6 +32,7 @@ const StrategyListPage = () => {
   const limit = 30;
   const navigate = useNavigate();
   const { user } = useAuthStore();
+  const { isToastVisible, hideToast } = useToastStore();
 
   const { data, isLoading, error } = useFetchStrategyList({
     tradingCycleId,
@@ -42,6 +44,12 @@ const StrategyListPage = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [page]);
+
+  useEffect(() => {
+    if (isToastVisible) {
+      hideToast();
+    }
+  }, [hideToast, isToastVisible]);
 
   const handleTradingCycleChange = (option: Option) => {
     setTradingCycleId(Number(option.value));


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #277

## 📋 작업 내용

관심 전략 내부 폴더 이동 API 연동 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![Dec-05-2024 16-58-28](https://github.com/user-attachments/assets/0a20ef20-0456-4e62-8680-dd9e675ab1b9)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

폴더 간 전략 이동을 위한 API를 통합하고, 폴더 모달에 로딩 및 오류 상태를 추가하며, 오류 처리를 통해 토스트 알림을 개선합니다.

새로운 기능:
- 사용자가 폴더를 선택하고 전략을 이동할 수 있도록 폴더 간 전략 이동을 위한 API를 통합합니다.

개선 사항:
- 폴더 데이터를 가져올 때 사용자 경험을 향상시키기 위해 폴더 모달에 로딩 및 오류 처리 상태를 추가합니다.
- 사용자 피드백을 개선하기 위해 오류 메시지와 유형을 포함하도록 토스트 알림을 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the API for moving strategies between folders, enhancing the folder modal with loading and error states, and improving toast notifications with error handling.

New Features:
- Integrate API for moving strategies between folders, allowing users to select a folder and move strategies accordingly.

Enhancements:
- Add loading and error handling states to the folder modal to improve user experience when fetching folder data.
- Enhance toast notifications to include error messages and types for better user feedback.

</details>