### PR TITLE
[Feat] 트레이더 프로필 조회 API 연동 및 CSS 수정

### DIFF
--- a/src/api/traderStrategies.ts
+++ b/src/api/traderStrategies.ts
@@ -11,16 +11,12 @@ interface FetchTraderStrategiesParams {
 }
 
 export const fetchTraderStrategies = async ({
-  role,
   traderId,
   page = 0,
   pageSize = 10,
 }: FetchTraderStrategiesParams) => {
   try {
     const response = await apiClient.get(API_ENDPOINTS.TRADERS.STRATEGIES(traderId), {
-      headers: {
-        Auth: role,
-      },
       params: {
         page,
         pageSize,

--- a/src/components/navigation/TraderProfilePageNav.tsx
+++ b/src/components/navigation/TraderProfilePageNav.tsx
@@ -10,7 +10,7 @@ import { useProfileImage } from '@/hooks/queries/useProfileImage';
 import { useSidebarProfileQuery } from '@/hooks/queries/useSidebarProfile';
 import theme from '@/styles/theme';
 
-const TraderNav = () => {
+const TraderProflieNav = () => {
   const { traderId } = useParams();
   const { data: profileImageData } = useProfileImage(traderId || ''); // 프로필 이미지 가져오기
   const imageSrc = profileImageData?.fileUrl;
@@ -26,14 +26,20 @@ const TraderNav = () => {
     },
   ];
 
+  const desc = `📌 월급쟁이 직장인이 자산가로 💸
+  🏡 부동산 실전 투자 (2018~)
+  👣 파워 “J” 대기업 연구원의 
+  재테크 이야기
+  🇺🇸 미국주식 스터디 운영 / 링크👇🏻 www.modu.Chwieob.fighting.com`;
+
   return (
     <div css={navContainerStyle}>
       <div css={navWrapper}>
         <ProfileSection
           userImage={imageSrc ?? userImage}
           userRole='트레이더'
-          nickname={profileData?.data.nickname ?? 'user4'}
-          desc={profileData?.data.introduction ?? '트레이더님의 소개글이 없습니다.'}
+          nickname='투자여왕'
+          desc={profileData?.data.introduction ?? desc}
         />
         <NavigationMenu items={TraderMyPageNavItems} />
       </div>
@@ -57,4 +63,4 @@ const navWrapper = css`
   background-color: ${theme.colors.main.white};
 `;
 
-export default TraderNav;
+export default TraderProflieNav;

--- a/src/components/page/mypage/ProfileSection.tsx
+++ b/src/components/page/mypage/ProfileSection.tsx
@@ -73,6 +73,7 @@ const descStyle = css`
   text-align: center;
   width: 225px;
   font-weight: 400;
+  white-space: pre-wrap;
   color: ${theme.colors.gray[700]};
 `;
 

--- a/src/hooks/queries/useFetchTraderStrategies.ts
+++ b/src/hooks/queries/useFetchTraderStrategies.ts
@@ -2,7 +2,6 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { fetchTraderStrategies } from '@/api/traderStrategies';
 import { UserRole } from '@/types/route';
-import { isValidAdminOrTraderRole } from '@/utils/roleUtils';
 
 interface UseFetchTraderStrategiesParams {
   role?: UserRole;
@@ -24,11 +23,7 @@ export const useFetchTraderStrategies = ({
         throw new Error('traderId가 없습니다.');
       }
 
-      if (!isValidAdminOrTraderRole(role)) {
-        throw new Error(`유효하지 않은 역할입니다: ${role}`);
-      }
-
-      const res = await fetchTraderStrategies({ role, traderId, page, pageSize });
+      const res = await fetchTraderStrategies({ traderId, page, pageSize });
 
       return {
         strategies: res.data,

--- a/src/layouts/TraderProfilePageLayout.tsx
+++ b/src/layouts/TraderProfilePageLayout.tsx
@@ -3,14 +3,14 @@ import { Outlet } from 'react-router-dom';
 
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
-import TraderPageNav from '@/components/navigation/TraderPageNav';
+import TraderProflieNav from '@/components/navigation/TraderProfilePageNav';
 import theme from '@/styles/theme';
 
-const TraderPageLayout = () => (
+const TraderProfilePageLayout = () => (
   <div css={wrapperStyle}>
     <Header />
     <main css={mainStyle}>
-      <TraderPageNav />
+      <TraderProflieNav />
       <Outlet />
     </main>
     <Footer />
@@ -32,4 +32,4 @@ const mainStyle = css`
   margin: 76px 0;
 `;
 
-export default TraderPageLayout;
+export default TraderProfilePageLayout;

--- a/src/pages/trader/TraderDetailPage.tsx
+++ b/src/pages/trader/TraderDetailPage.tsx
@@ -16,7 +16,6 @@ const TraderDetailPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPageFromQuery = parseInt(searchParams.get('page') || '1', 10);
   const { traderId } = useParams();
-  console.log('traderId', traderId);
 
   const { strategies, isLoading, isError, totalPages, totalElements, pageSize } =
     useFetchTraderStrategies({

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -6,7 +6,7 @@ import InvestorMypageLayout from '@/layouts/InvestorMypageLayout';
 import NotFoundLayout from '@/layouts/NotFoundLayout';
 import RootLayout from '@/layouts/RootLayout';
 import TraderMyPageLayout from '@/layouts/TraderMyPageLayout';
-import TraderPageLayout from '@/layouts/TraderPageLayout';
+import TraderProfilePageLayout from '@/layouts/TraderProfilePageLayout';
 import StockTypeListPage from '@/pages/admin/stock-type/StockTypeListPage';
 import StrategyApprovalListPage from '@/pages/admin/strategy/StrategyApprovalListPage';
 import TradingTypeListPage from '@/pages/admin/trading-type/TradingTypeListPage';
@@ -237,7 +237,7 @@ export const router = createBrowserRouter(
     },
     {
       path: ROUTES.HOME.PATH,
-      element: <TraderPageLayout />,
+      element: <TraderProfilePageLayout />,
       errorElement: <ErrorPage />, // 에러 처리 페이지
       children: [
         {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #346

## 📋 작업 내용

트레이더 프로필 조회 API 연동 및 CSS 수정 (API 권한 수정)
공개된 전략만 보임

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/6e7942e4-5da7-46f2-9436-3638db410765">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

트레이더 프로필 API를 통합하여 공개 전략과 함께 트레이더 프로필을 표시하고, 더 나은 프레젠테이션을 위해 CSS를 업데이트합니다. 트레이더 전략을 가져오는 함수에서 역할 검증을 제거하고, 이러한 변경 사항을 반영하기 위해 관련 구성 요소와 레이아웃을 조정합니다.

새로운 기능:
- 공개 전략과 함께 트레이더 프로필을 표시하기 위해 트레이더 프로필 API를 통합합니다.

개선 사항:
- 텍스트 줄 바꿈 처리를 포함하여 트레이더 프로필의 표시를 개선하기 위해 CSS를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the trader profile API to display trader profiles with public strategies and update the CSS for better presentation. Remove role validation from the fetch trader strategies function and adjust related components and layouts to reflect these changes.

New Features:
- Integrate the trader profile API to display trader profiles with public strategies.

Enhancements:
- Update CSS to improve the display of trader profiles, including handling of text wrapping.

</details>