### PR TITLE
[Fix] 상세 페이지 이동시 Nav active 풀리는 이슈 해결 

### DIFF
--- a/src/components/common/NavigationMenu.tsx
+++ b/src/components/common/NavigationMenu.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 
 import NavMenuItem from '@/components/common/NavMenuItem';
+import { ROUTES } from '@/constants/routes';
 
 interface NavigationMenuProps {
   items: {
@@ -12,7 +13,30 @@ interface NavigationMenuProps {
 
 const NavigationMenu = ({ items }: NavigationMenuProps) => {
   const location = useLocation();
-  const isActive = (path: string) => location.pathname === path;
+
+  const isActive = (path: string) => {
+    if (location.pathname === path) {
+      return true;
+    }
+
+    if (path === ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS) {
+      return (
+        location.pathname.startsWith(ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS) &&
+        (location.pathname === ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS ||
+          location.pathname.startsWith('/mypage/investor/following'))
+      );
+    }
+
+    if (path === ROUTES.MYPAGE.INVESTOR.MYINQUIRY.LIST) {
+      return location.pathname.startsWith(path);
+    }
+
+    if (path === ROUTES.MYPAGE.TRADER.INQUIRIES.LIST) {
+      return location.pathname.startsWith(path);
+    }
+
+    return false;
+  };
 
   return (
     <nav>

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -27,9 +27,9 @@ const InvestorFollowFolderPage = () => {
   const { data, isLoading, isError, refetch } = useFollowingList(Number(folderId), page - 1, limit);
   const { data: folderList } = useFolderList(page - 1, limit);
 
-  const folderTitle = folderList.data
-    .filter((v: Folder) => v.folderId === Number(folderId))
-    .map((v: Folder) => v.folderName);
+  const folderTitle = folderList?.data
+    ?.filter((v: Folder) => v.folderId === Number(folderId))
+    ?.map((v: Folder) => v.folderName);
 
   const handleMoveFolder = (strategyId: number) => {
     let selectedFolderId = '';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #355

## 📋 작업 내용

상세 페이지 이동시 Nav active 풀리는 이슈 해결 (투자자, 트레이더 마이페이지 모든 메뉴 수정 완료)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

### 전

![Dec-06-2024 01-28-00](https://github.com/user-attachments/assets/a24cd830-6630-4356-ae9e-3b4fdcd8c65c)

### 후

![Dec-06-2024 01-28-13](https://github.com/user-attachments/assets/055108ff-ab52-4ec7-aa8f-265b569a7762)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

상세 페이지로 이동할 때 내비게이션 메뉴의 활성 상태 문제를 수정하고 InvestorFollowFolderPage 컴포넌트에서 폴더 제목 검색을 향상시킵니다.

버그 수정:
- 투자자 및 트레이더 마이 페이지의 상세 페이지로 이동할 때 내비게이션 메뉴가 활성 상태를 잃는 문제를 수정합니다.

향상 사항:
- 선택적 체이닝을 추가하여 InvestorFollowFolderPage 컴포넌트에서 폴더 제목 검색의 견고성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the navigation menu active state issue when moving to detailed pages and enhance folder title retrieval in the InvestorFollowFolderPage component.

Bug Fixes:
- Fix the issue where the navigation menu loses its active state when navigating to detailed pages for both investor and trader my pages.

Enhancements:
- Improve the robustness of the folder title retrieval in the InvestorFollowFolderPage component by adding optional chaining.

</details>