### PR TITLE
[Feat] 프로필 이미지 업로드, 삭제 기능 구현

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -41,7 +41,9 @@ export const API_ENDPOINTS = {
   },
   INQUIRY: '/api/consultations', // 나의 문의 , 문의 등록
   FILES: {
+    PROFILE_UPLOAD: '/api/files/profile', // 프로필 이미지 업로드
     PROFILE_URL: (memberId: string) => `/api/files/profile/${memberId}`, // 프로필 이미지 URL
+    DELETE_PROFILE: (fileId: string) => `/api/files/profile/${fileId}`,
     PROPOSAL: '/api/files/proposal', // 제안서 파일 업로드
     ICON: '/api/files/icon', //아이콘 업로드
   },

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 
-import apiClient from '@/api/apiClient';
+import apiClient, { createFormDataRequest } from '@/api/apiClient';
 import { API_ENDPOINTS } from '@/api/apiEndpoints';
 import {
   ChangePasswordResponse,
@@ -31,6 +31,31 @@ export const getProfileImageUrl = async (memberId: string): Promise<ProfileUrlRe
           throw new Error('프로필 이미지 URL 조회 중 오류가 발생했습니다.');
       }
     }
+    throw error;
+  }
+};
+
+export const uploadProfileImage = async (fileUrl: string, fileItem: File) => {
+  const formData = createFormDataRequest({ file: fileItem });
+
+  try {
+    const res = await apiClient.post(API_ENDPOINTS.FILES.PROFILE_UPLOAD, formData, {
+      params: {
+        fileUrl: decodeURIComponent(fileUrl),
+      },
+    });
+    return res.data;
+  } catch (error) {
+    console.error('failed to upload icon image');
+  }
+};
+
+export const deleteProfileImage = async (fileId: string) => {
+  try {
+    const response = await apiClient.delete(API_ENDPOINTS.FILES.DELETE_PROFILE(fileId));
+    return response.data;
+  } catch (error) {
+    console.error('Failed to delete profile image:', error);
     throw error;
   }
 };

--- a/src/components/navigation/InvestorMypageNav.tsx
+++ b/src/components/navigation/InvestorMypageNav.tsx
@@ -20,10 +20,6 @@ const InvestorMypageNav = () => {
   const imageSrc = profileImageData?.fileUrl;
   const { data: profileData } = useSidebarProfileQuery();
 
-  const [userImage] = useState(
-    'https://i.pinimg.com/474x/78/04/d7/7804d73be61366364997b925a613f438.jpg'
-  );
-
   const InvestorMypageNavItems = [
     {
       to: `${ROUTES.MYPAGE.INVESTOR.FOLLOWING.FOLDERS}`,
@@ -49,7 +45,7 @@ const InvestorMypageNav = () => {
     <div css={navContainerStyle}>
       <div css={navWrapper}>
         <ProfileSection
-          userImage={imageSrc ?? userImage}
+          userImage={imageSrc}
           userRole={profileData?.data.memberType === 'TRADER' ? '트레이더' : '투자자'}
           nickname={profileData?.data.nickname ?? '투자자님'}
           desc={profileData?.data.introduction ?? '투자자님의 소개글이 없습니다.'}

--- a/src/components/navigation/InvestorMypageNav.tsx
+++ b/src/components/navigation/InvestorMypageNav.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { GrLogout } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';

--- a/src/components/navigation/TraderMyPageNav.tsx
+++ b/src/components/navigation/TraderMyPageNav.tsx
@@ -19,9 +19,6 @@ const TraderMyPageNav = () => {
   const { data: profileImageData } = useProfileImage(user?.memberId || ''); // 프로필 이미지 가져오기
   const imageSrc = profileImageData?.fileUrl;
   const { data: profileData } = useSidebarProfileQuery();
-  const [userImage] = useState(
-    'https://i.pinimg.com/736x/2b/4c/91/2b4c913711c4a8be893aa873b3b23193.jpg'
-  );
 
   const TraderMyPageNavItems = [
     {
@@ -48,7 +45,7 @@ const TraderMyPageNav = () => {
     <div css={navContainerStyle}>
       <div css={navWrapper}>
         <ProfileSection
-          userImage={imageSrc ?? userImage}
+          userImage={imageSrc}
           userRole={profileData?.data.memberType === 'TRADER' ? '트레이더' : '투자자'}
           nickname={profileData?.data.nickname ?? '트레이더님'}
           desc={profileData?.data.introduction ?? '트레이더님의 소개글이 없습니다.'}

--- a/src/components/navigation/TraderMyPageNav.tsx
+++ b/src/components/navigation/TraderMyPageNav.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { GrLogout } from 'react-icons/gr';
 import { useNavigate } from 'react-router-dom';

--- a/src/components/page/mypage/ProfileSection.tsx
+++ b/src/components/page/mypage/ProfileSection.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { BsFillPersonFill } from 'react-icons/bs';
 
+import Avatar from '@/components/common/Avatar';
 import theme from '@/styles/theme';
 
 interface ProfileSectionProps {
-  userImage: string | null;
+  userImage?: string | null;
   userRole: '트레이더' | '투자자';
   nickname: string;
   desc: string;
@@ -13,11 +13,7 @@ interface ProfileSectionProps {
 const ProfileSection = ({ userImage, userRole, nickname, desc }: ProfileSectionProps) => (
   <div css={profileWrapper}>
     <div css={profileImageStyle}>
-      {userImage ? (
-        <img src={userImage} alt='프로필사진' />
-      ) : (
-        <BsFillPersonFill color='white' size={60} />
-      )}
+      <Avatar src={userImage} alt='프로필사진' size='100%' />
     </div>
     <div css={roleStyle}>{userRole}</div>
     <div css={nicknameStyle}>{nickname}</div>
@@ -41,7 +37,6 @@ const profileImageStyle = css`
   border-radius: 50%;
   margin-bottom: 24px;
   overflow: hidden;
-  background-color: ${theme.colors.gray[300]};
 
   img {
     width: 100%;

--- a/src/hooks/mutations/useProfileImageMutations.ts
+++ b/src/hooks/mutations/useProfileImageMutations.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { uploadProfileImage, deleteProfileImage } from '@/api/profile';
+
+export const useUploadProfileImage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ fileUrl, fileItem }: { fileUrl?: string; fileItem: File }) => {
+      if (!fileUrl || !fileItem) {
+        console.error('fileUrl 파일주소가 없음');
+        throw new Error('fileUrl is required'); // 에러를 명시적으로 던짐
+      }
+      return uploadProfileImage(fileUrl, fileItem);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['profileImage'],
+      });
+    },
+    onError: (error) => {
+      console.error('프로필 이미지 수정 실패:', error);
+    },
+  });
+};
+
+export const useDeleteProfileImage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (fileId: string) => deleteProfileImage(fileId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['profileImage'],
+      });
+    },
+    onError: (error) => {
+      console.error('Error deleting profile image:', error);
+    },
+  });
+};

--- a/src/hooks/mutations/useProfileImageMutations.ts
+++ b/src/hooks/mutations/useProfileImageMutations.ts
@@ -9,7 +9,7 @@ export const useUploadProfileImage = () => {
     mutationFn: ({ fileUrl, fileItem }: { fileUrl?: string; fileItem: File }) => {
       if (!fileUrl || !fileItem) {
         console.error('fileUrl 파일주소가 없음');
-        throw new Error('fileUrl is required'); // 에러를 명시적으로 던짐
+        throw new Error('fileUrl is required');
       }
       return uploadProfileImage(fileUrl, fileItem);
     },

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -3,6 +3,7 @@ export interface ProfileUrlResponse {
   message: string;
   category: string;
   displayName: string;
+  fileId: string;
 }
 
 export interface SidebarProfileResponse {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

ProfileManager 컴포넌트에 프로필 이미지 업로드 및 삭제 기능을 구현하여 사용자 프로필 관리 기능을 향상시킵니다.

새로운 기능:
- ProfileManager 컴포넌트에서 프로필 이미지를 업로드하고 삭제하는 기능 추가.

개선 사항:
- 프로필 세부 정보를 위한 보다 구조화된 상태 관리를 사용하도록 ProfileManager 리팩토링.
- 프로필 이미지 작업 및 개인 정보 업데이트에 대한 토스트 알림 개선.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement profile image upload and deletion features in the ProfileManager component, enhancing user profile management capabilities.

New Features:
- Add functionality to upload and delete profile images in the ProfileManager component.

Enhancements:
- Refactor ProfileManager to use a more structured state management for profile details.
- Improve toast notifications for profile image operations and personal details updates.

</details>