### PR TITLE
[feat] 회원 탈퇴기능 구현 

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -63,5 +63,6 @@ export const API_ENDPOINTS = {
     SIDEBAR_PROFILE: (memberId: string) => `/api/members/${memberId}/sidebar-profile`, // 사이드바 프로필 정보 조회
     DETAILS: '/api/members/details', // 회원 상세 정보 조회
     PASSWORD_CHANGE: '/api/members/change-password', // 비밀번호 변경
+    WITHDRAWAL: '/api/members/withdrawal', // 회원탈퇴
   },
 };

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -159,3 +159,25 @@ export const changePassword = async ({
     throw new Error('비밀번호 변경 중 오류가 발생했습니다.');
   }
 };
+
+export const withdrawMember = async () => {
+  try {
+    const response = await apiClient.delete(API_ENDPOINTS.MEMBERS.WITHDRAWAL);
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      switch (error.response?.status) {
+        case 400:
+          throw new Error('잘못된 요청: 입력값을 확인하세요.');
+        case 401:
+          throw new Error('권한 없음: 로그인이 필요합니다.');
+        case 405:
+          throw new Error('잘못된 요청 방식: HTTP 메서드가 올바르지 않습니다.');
+        case 500:
+          throw new Error('서버 오류: 서버에서 문제가 발생했습니다.');
+        default:
+          throw new Error('알 수 없는 오류가 발생했습니다.');
+      }
+    }
+  }
+};

--- a/src/hooks/mutations/useWithdrawMember.ts
+++ b/src/hooks/mutations/useWithdrawMember.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { withdrawMember } from '@/api/profile';
+
+export const useWithdrawMember = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => withdrawMember(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['user'],
+      });
+    },
+    onError: (error) => {
+      console.error('회원 탈퇴 실패:', error);
+    },
+  });
+};

--- a/src/pages/auth/WithdrawalSuccessPage.tsx
+++ b/src/pages/auth/WithdrawalSuccessPage.tsx
@@ -1,7 +1,45 @@
-const WithdrawalSuccessPage = () => (
-  <div>
-    <h1>정상적으로 회원탈퇴 하였습니다.</h1>
-  </div>
-);
+import { css } from '@emotion/react';
+import { useNavigate } from 'react-router-dom';
+
+import Button from '@/components/common/Button';
+import { ROUTES } from '@/constants/routes';
+import theme from '@/styles/theme';
+
+const WithdrawalSuccessPage = () => {
+  const navigate = useNavigate();
+  const handleMoveHomePage = () => {
+    navigate(ROUTES.HOME.PATH);
+  };
+  return (
+    <div css={containerStyle}>
+      <h2>탈퇴가 완료되었습니다</h2>
+      <p>그동안 서비스를 이용해주셔서 감사드리며, 더 나은 서비스로 다시 찾아뵙겠습니다.</p>
+      <Button onClick={handleMoveHomePage}>홈으로</Button>
+    </div>
+  );
+};
+
+const containerStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - (240px + 94px));
+
+  h2 {
+    margin-bottom: 10px;
+    ${theme.textStyle.headings.h2}
+  }
+
+  p {
+    margin-bottom: 40px;
+  }
+
+  button {
+    width: 154px;
+    height: 60px;
+    padding: 20px 32px;
+  }
+`;
 
 export default WithdrawalSuccessPage;

--- a/src/pages/mypage/investor/InvestorProfilePage.tsx
+++ b/src/pages/mypage/investor/InvestorProfilePage.tsx
@@ -1,20 +1,65 @@
 import { css } from '@emotion/react';
 import { MdOutlineNoAccounts } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import Toast from '@/components/common/Toast';
 import PasswordChange from '@/components/page/mypage/PasswordChange';
 import ProfileManager from '@/components/page/mypage/ProfileManager';
+import { ROUTES } from '@/constants/routes';
+import { useWithdrawMember } from '@/hooks/mutations/useWithdrawMember';
+import { useAdminAuthStore } from '@/stores/adminAuthStore';
+import { useAuthStore } from '@/stores/authStore';
+import useModalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/toastStore';
 
-const InvestorProfilePage = () => (
-  <div css={myPageWrapperStyle}>
-    <ProfileManager />
-    <PasswordChange />
-    <Button variant='ghostGray' customStyle={logoutStyle} size='sm'>
-      <MdOutlineNoAccounts size={16} />
-      <span>회원 탈퇴</span>
-    </Button>
-  </div>
-);
+const InvestorProfilePage = () => {
+  const navigate = useNavigate();
+  const { clearAuth } = useAuthStore();
+  const { clearAdminAuth } = useAdminAuthStore();
+  const { mutate: withdrawMember } = useWithdrawMember();
+  const { openModal } = useModalStore();
+  const { isToastVisible, hideToast, message, showToast } = useToastStore();
+
+  const handleWithdraw = () => {
+    openModal({
+      type: 'warning',
+      title: '회원탈퇴',
+      desc: `탈퇴 시 모든 데이터는 복구되지 않으며,\n 재가입 시에도 유지되지 않습니다.\n 탈퇴 후 로그아웃됩니다.`,
+      onAction: () => {
+        withdrawMember(undefined, {
+          onSuccess: () => {
+            clearAuth();
+            clearAdminAuth();
+            navigate(ROUTES.AUTH.WITHDRAWAL.SUCCESS);
+          },
+          onError: () => {
+            showToast('회원 탈퇴 실패했습니다.', 'error');
+          },
+        });
+      },
+    });
+  };
+
+  return (
+    <>
+      <div css={myPageWrapperStyle}>
+        <ProfileManager />
+        <PasswordChange />
+        <Button variant='ghostGray' customStyle={logoutStyle} size='sm' onClick={handleWithdraw}>
+          <MdOutlineNoAccounts size={16} />
+          <span>회원 탈퇴</span>
+        </Button>
+
+        {isToastVisible && (
+          <Toast message={message} isVisible={isToastVisible} onClose={hideToast} />
+        )}
+      </div>
+      <Modal />
+    </>
+  );
+};
 
 const myPageWrapperStyle = css`
   width: 955px;

--- a/src/pages/mypage/trader/TraderProfilePage.tsx
+++ b/src/pages/mypage/trader/TraderProfilePage.tsx
@@ -1,20 +1,64 @@
 import { css } from '@emotion/react';
 import { MdOutlineNoAccounts } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import Toast from '@/components/common/Toast';
 import PasswordChange from '@/components/page/mypage/PasswordChange';
 import ProfileManager from '@/components/page/mypage/ProfileManager';
+import { ROUTES } from '@/constants/routes';
+import { useWithdrawMember } from '@/hooks/mutations/useWithdrawMember';
+import { useAdminAuthStore } from '@/stores/adminAuthStore';
+import { useAuthStore } from '@/stores/authStore';
+import useModalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/toastStore';
 
-const TraderProfilePage = () => (
-  <div css={myPageWrapperStyle}>
-    <ProfileManager />
-    <PasswordChange />
-    <Button variant='ghostGray' customStyle={logoutStyle} size='sm'>
-      <MdOutlineNoAccounts size={16} />
-      <span>회원 탈퇴</span>
-    </Button>
-  </div>
-);
+const TraderProfilePage = () => {
+  const navigate = useNavigate();
+  const { clearAuth } = useAuthStore();
+  const { clearAdminAuth } = useAdminAuthStore();
+  const { mutate: withdrawMember } = useWithdrawMember();
+  const { openModal } = useModalStore();
+  const { isToastVisible, hideToast, message, showToast } = useToastStore();
+
+  const handleWithdraw = () => {
+    openModal({
+      type: 'warning',
+      title: '회원탈퇴',
+      desc: `탈퇴 시 모든 데이터는 복구되지 않으며,\n 재가입 시에도 유지되지 않습니다.\n 탈퇴 후 로그아웃됩니다.`,
+      onAction: () => {
+        withdrawMember(undefined, {
+          onSuccess: () => {
+            clearAuth();
+            clearAdminAuth();
+            navigate(ROUTES.AUTH.WITHDRAWAL.SUCCESS);
+          },
+          onError: () => {
+            showToast('회원 탈퇴 실패했습니다.', 'error');
+          },
+        });
+      },
+    });
+  };
+  return (
+    <>
+      <div css={myPageWrapperStyle}>
+        <ProfileManager />
+        <PasswordChange />
+        <Button variant='ghostGray' customStyle={logoutStyle} size='sm' onClick={handleWithdraw}>
+          <MdOutlineNoAccounts size={16} />
+          <span>회원 탈퇴</span>
+        </Button>
+
+        {isToastVisible && (
+          <Toast message={message} isVisible={isToastVisible} onClose={hideToast} />
+        )}
+      </div>
+      <Modal />
+    </>
+  );
+};
 
 const myPageWrapperStyle = css`
   width: 955px;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #345

## 📋 작업 내용

회원탈퇴. 재가입해서 회원탈퇴를 3-4번함...

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/05c9dd14-b9ef-457f-8e63-7f38783fe52a




## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

회원 탈퇴 기능을 구현하여 사용자가 확인 및 피드백과 함께 계정을 삭제할 수 있도록 합니다. 탈퇴 성공 페이지를 개선된 스타일링과 탐색 옵션으로 향상시킵니다.

새로운 기능:
- 투자자 및 거래자 프로필 페이지 모두에 대한 회원 탈퇴 기능을 구현하여 확인 모달 및 성공 토스트 알림을 포함합니다.

개선 사항:
- 스타일이 적용된 메시지와 홈 페이지로 돌아가는 버튼을 포함하여 WithdrawalSuccessPage를 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement member withdrawal functionality, allowing users to delete their accounts with confirmation and feedback. Enhance the withdrawal success page with improved styling and navigation options.

New Features:
- Implement member withdrawal functionality for both investor and trader profile pages, including a confirmation modal and success toast notification.

Enhancements:
- Enhance the WithdrawalSuccessPage with a styled message and a button to navigate back to the home page.

</details>